### PR TITLE
Fix image get frequency

### DIFF
--- a/pipeline/image/main.py
+++ b/pipeline/image/main.py
@@ -125,7 +125,7 @@ class FitsImage(Image):
         self.freq_eff = None
         self.freq_bw = None
         try:
-            if header['TELESCOP'] in ('LOFAR', 'AARTFAAC'):
+            if ('TELESCOP' in header) and (header['TELESCOP'] in ('LOFAR', 'AARTFAAC')):
                 self.freq_eff = header['RESTFRQ']
                 if 'RESTBW' in header:
                     self.freq_bw = header['RESTBW']


### PR DESCRIPTION
Currently if `TELESCOP` is not in the header then get_frequency will fail.

This commit updates the function to check that the `TELESCOP` key is actually present in the header before attempting to read the associated value.

Fixes issue #4.