### PR TITLE
fixed datatables ajax error for catalog overview

### DIFF
--- a/pipeline/serializers.py
+++ b/pipeline/serializers.py
@@ -45,7 +45,7 @@ class SourceSerializer(serializers.ModelSerializer):
 
 class CatalogSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(read_only=True)
-    sources = serializers.SerializerMethodField()
+    sources = serializers.IntegerField(read_only=True)
     ave_ra = serializers.SerializerMethodField()
     ave_dec = serializers.SerializerMethodField()
 
@@ -53,9 +53,6 @@ class CatalogSerializer(serializers.ModelSerializer):
         model = Catalog
         exclude = ['dataset']
         datatables_always_serialize = ('id',)
-
-    def get_sources(self, catalog):
-        return catalog.source_set.count()
 
     def get_ave_ra(self, catalog):
         return deg2hms(catalog.ave_ra, hms_format=True)

--- a/pipeline/views.py
+++ b/pipeline/views.py
@@ -178,7 +178,7 @@ def catalogIndex(request):
 
 
 class CatalogViewSet(ModelViewSet):
-    queryset = Catalog.objects.all()
+    queryset = Catalog.objects.annotate(sources=Count("source"))
     serializer_class = CatalogSerializer
 
 


### PR DESCRIPTION
When attempting to sort or use the pagination controls on the catalog
overview page, an AJAX error that no field "sources" exists for the
Catalog model. This is true! `sources` is inserted into the serializer
as an aggregate result. This fix replaces the serializer method that
calculates the number of sources with an annotation to the queryset
passed to the serializer, defined in the view. This allows the `sources`
property to be sorted and filtered on by the datatables.

Fixes #67.