### PR TITLE
log exception on missing FITS header keywords

### DIFF
--- a/pipeline/image/main.py
+++ b/pipeline/image/main.py
@@ -67,10 +67,17 @@ class FitsImage(Image):
         self.fov_bmin = None
 
         if header.get('TELESCOP', None) == 'ASKAP':
-            self.time = pd.Timestamp(header['DATE-OBS'], tz=header['TIMESYS'])
-            self.beam_bmaj = header['BMAJ']
-            self.beam_bmin = header['BMIN']
-            self.beam_bpa = header['BPA']
+            try:
+                self.time = pd.Timestamp(header['DATE-OBS'], tz=header['TIMESYS'])
+                self.beam_bmaj = header['BMAJ']
+                self.beam_bmin = header['BMIN']
+                self.beam_bpa = header['BPA']
+            except KeyError as e:
+                logger.exception(
+                    "Image %s does not contain expected FITS header keywords.",
+                    self.name,
+                )
+                raise e
 
             params = {
                 'header': header,

--- a/pipeline/management/commands/runpipeline.py
+++ b/pipeline/management/commands/runpipeline.py
@@ -3,6 +3,7 @@ import logging
 
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
+from django.db import transaction
 
 from pipeline.pipeline.main import Pipeline
 from pipeline.utils.utils import load_validate_cfg, RunStats, StopWatch
@@ -29,6 +30,7 @@ class Command(BaseCommand):
             help='path to the dataset folder'
         )
 
+    @transaction.atomic
     def handle(self, *args, **options):
         # configure logging
         if options['verbosity'] > 1:


### PR DESCRIPTION
An exception is logged when ingesting a FITS image and an expected
header keyword is missing. Also made the pipeline processing an atomic
transaction so that if an error is encountered, the database commits are
rolled back.

Fixes #68.