### PR TITLE
change chart data date format to ISO

### DIFF
--- a/pipeline/views.py
+++ b/pipeline/views.py
@@ -355,8 +355,6 @@ def catalogDetail(request, id, action=None):
     ).order_by('datetime').values(*tuple(cols)))
     for src in sources:
         src['datetime'] = src['datetime'].isoformat()
-        # for key in ['flux_int', 'flux_int_err', 'flux_peak', 'flux_peak_err']:
-        #     src[key] = src[key] * 1.e3
 
     # add source count
     catalog['sources'] = len(sources)


### PR DESCRIPTION
This ended up being a much simpler fix than I thought!

---
Safari cannot construct Date objects from the same date format strings
as Chrome. This fix changes the date string serialization to ISO format
which most browsers should support.