### PR TITLE
replace nan values with 0

### DIFF
--- a/pipeline/pipeline/association.py
+++ b/pipeline/pipeline/association.py
@@ -44,7 +44,7 @@ def groupby_funcs(row, first_img):
     d.pop('Nsrc')
     # set new catalog/source
     d['new'] = True if first_img in row['img'] else False
-    return pd.Series(d)
+    return pd.Series(d).fillna(0.0)
 
 
 def get_catalog_models(row, dataset=None):


### PR DESCRIPTION
The variability metrics are sometimes called on lightcurves with a
single measurement. Since these metrics compute the sample
standard deviation, it will return NaN in those cases. This replaces
all NaN values returned by the association groupby functions with 0.
The rationale is that it does not make sense to compute variability
metrics for a source with only measurement. Setting them to 0 will
exclude them from being considered when analysing source variability.

Fixes #80.