### PR TITLE
Add >1 check to on sky sep calculation

### DIFF
--- a/pipeline/image/utils.py
+++ b/pipeline/image/utils.py
@@ -16,12 +16,10 @@ def on_sky_sep(ra_1, ra_2, dec_1, dec_2):
         np.sin(dec_1) * np.sin(dec_2) +
         np.cos(dec_1) * np.cos(dec_2) * np.cos(ra_1 - ra_2)
     )
+    # fix errors on separation values over 1
+    separation[separation > 1.] = 1.
 
-   separation[separation > 1.] = 1.
-
-    separation = np.arccos(separation)
-
-    return separation
+    return np.arccos(separation)
 
 
 def calc_error_radius(ra, ra_err, dec, dec_err):


### PR DESCRIPTION
Adds a check for values above 1 to be passed through `arccos`. This should very rarely happen (1/~200k sources in the entire S190814bv data), if one is found it replaces it with 1, i.e. an end result of 0. A reminder that the user can specify a systematic uncertainty so sources will not have 0 positional error.

Fixes #197.