### PR TITLE
Added tool tips and units to write config form

### DIFF
--- a/static/js/run-config.js
+++ b/static/js/run-config.js
@@ -1,5 +1,7 @@
 $(document).ready(function() {
 
+  $('[data-toggle="tooltip"]').tooltip();
+
   $("#newPipeRunButton").on('click', function(e) {
     // hide second part of form
     $("#pipeRunConfigForm").hide();

--- a/templates/generic_table.html
+++ b/templates/generic_table.html
@@ -289,9 +289,4 @@
 {{ datatable|json_script:"datatable-conf" }}
 <script src="{% static 'js/datatables-pipeline.min.js' %}"></script>
 
-<script>
-$(document).ready(function(){
-  $('[data-toggle="tooltip"]').tooltip(); 
-});
-</script>
 {% endblock custom_page_scripts %}


### PR DESCRIPTION
I've added information tool tips to the config form. And tidied up some of the value names.

<img width="1287" alt="Screen Shot 2020-08-10 at 14 05 30" src="https://user-images.githubusercontent.com/3306161/89751236-9d1c6700-db12-11ea-916d-b2662df3ec4d.png">
<img width="1289" alt="Screen Shot 2020-08-10 at 14 05 45" src="https://user-images.githubusercontent.com/3306161/89751241-a1488480-db12-11ea-9070-7e8fdc0a7f6d.png">



