### PR TITLE
compile JS9 without helper option

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,7 +70,7 @@ function js9Dir() {
 
 function js9MakeConfig() {
   var config = run(
-    './configure --with-webdir=' + paths.js9Target + ' --with-helper=nodejs',
+    './configure --with-webdir=' + paths.js9Target,
     {cwd: './node_modules/js9'}
   )
   return config();


### PR DESCRIPTION
Fixes #272. We don't currently use any of the server-side helper functionality.