### PR TITLE
fix lightcurve header floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Fixed misalignment of lightcurve card header text and the flux type radio buttons [#386](https://github.com/askap-vast/vast-pipeline/pull/386).
 - Fixes incorrently named GitHub `social-auth` settings variable that prevented users from logging in with GitHub [#372](https://github.com/askap-vast/vast-pipeline/pull/372).
 - Fixes webinterface navbar overspill at small sizes [#345](https://github.com/askap-vast/vast-pipeline/pull/345).
 - Fixes webinterface favourite source table [#345](https://github.com/askap-vast/vast-pipeline/pull/345).
@@ -82,6 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#386](https://github.com/askap-vast/vast-pipeline/pull/386) fix: fix lightcurve header floats.
 - [#368](https://github.com/askap-vast/vast-pipeline/pull/368) feat: vast-candidates merger: Add user commenting
 - [#370](https://github.com/askap-vast/vast-pipeline/pull/370) feat: moved sb-admin-2 assets to dependencies.
 - [#382](https://github.com/askap-vast/vast-pipeline/pull/380) feat: Refactored bulk uploading of objects.

--- a/templates/source_detail.html
+++ b/templates/source_detail.html
@@ -194,7 +194,7 @@
       <!-- Area Chart -->
       <div class="card shadow h-100">
         <div class="card-header py-3 clearfix" id="lightcurveHeader">
-          <h6 class="m-0 font-weight-bold text-primary">Light Curve</h6>
+          <h6 class="m-0 font-weight-bold text-primary float-left">Light Curve</h6>
           <div class="float-right" id="fluxTypeRadioContainer">
             <div class="form-check form-check-inline">
               <input class="form-check-input" type="radio" name="fluxTypeRadio" id="fluxTypeRadioPeak" value="peak" checked>


### PR DESCRIPTION
Tiny fix to correct the misalignment of the lightcurve card header text and the flux type radio buttons. I must have missed the `float-left` class during a merge.