### PR TITLE
fix "back to top" TOC link

### DIFF
--- a/docs/theme/js/extra.js
+++ b/docs/theme/js/extra.js
@@ -1,9 +1,10 @@
 function addGoToTop() {
-  document.querySelectorAll('[aria-label="Table of contents"]')[1].innerHTML += '<a href="#top" id="gototop">Back to top</a>';
+  let toc = document.querySelectorAll('[aria-label="Table of contents"]');
+  // only add the link if the TOC is on the page (it's the second one)
+  if (toc.length > 1) {
+    toc[1].innerHTML += '<a href="#top" id="gototop">Back to top</a>';
+  }
 }
-
-// window.open = addGoToTop();
-document.addEventListener('scroll', addGoToTop())
 
 window.MathJax = {
   tex: {
@@ -18,13 +19,27 @@ window.MathJax = {
   }
 };
 
+/*
+mkdocs-material loads local pages via XHR (they call it "instant loading") which speeds
+up navigation by preventing a full page reload. This means that any custom JS is only
+run on the first page load and skipped on subsequent loads. Below, we add functions
+that should be called on each page load by subsribing them to the document$ observable,
+i.e. any time the document changes, execute the following.
+*/
+// render MathJax
 document$.subscribe(() => {
   MathJax.typesetPromise()
 })
 
+// configure images to use lightgallery
 document$.subscribe(function() {
   var elements = document.getElementsByClassName("lightgallery");
   for(var i=0; i<elements.length; i++) {
      lightGallery(elements[i], {counter: false});
   }
+})
+
+// add a "Back to top" link to the TOC
+document$.subscribe(() => {
+  addGoToTop();
 })


### PR DESCRIPTION
The code to add a "back to top" link to the table of contents would fail with an error message on pages that don't have a TOC.
The link was also never added if the user started on a page without a TOC as the mkdocs-material instant loading feature prevents JS from being executed when navigating between local docs pages. This patch ensures the link is always added.