### PR TITLE
Fix README link and documentation 404 assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Added
 
+- Added `site_url` to the mkdocs config so static asset URLs have the correct base URL [#543](https://github.com/askap-vast/vast-pipeline/pull/543).
+
 #### Changed
 
 #### Fixed
 
+- Fixed outdated installation link in README [#543](https://github.com/askap-vast/vast-pipeline/pull/543).
+
 #### Removed
 
 #### List of PRs
+
+- [#543](https://github.com/askap-vast/vast-pipeline/pull/543): fix, doc: Fix README link and documentation 404 assets.
 
 ## [1.0.0](https://github.com/askap-vast/vast-pipeline/releases/v1.0.0) (2021-05-21)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This repository holds the code of the VAST Pipeline, a radio transient detection pipeline for the ASKAP survey science project, VAST.
 
-Please read the [Installation Instructions](https://vast-survey.org/vast-pipeline/quickstart/installation/). If you have any questions or feedback, we welcome you to open an [issue](https://github.com/askap-vast/vast-pipeline/issues). If you are interested in contributing to the code, please read and follow the [Contributing and Developing Guidelines](https://vast-survey.org/vast-pipeline/developing/intro/).
+Please read the [Installation Instructions](https://vast-survey.org/vast-pipeline/gettingstarted/installation/). If you have any questions or feedback, we welcome you to open an [issue](https://github.com/askap-vast/vast-pipeline/issues). If you are interested in contributing to the code, please read and follow the [Contributing and Developing Guidelines](https://vast-survey.org/vast-pipeline/developing/intro/).
 
 If using this tool in your research, please cite Murphy, et al. (2021).
 

--- a/README.md
+++ b/README.md
@@ -50,4 +50,6 @@ The VAST Pipeline development was supported by:
 * Software support resources awarded under the Astronomy Data and Computing Services (ADACS) Merit Allocation Program. ADACS is funded from the Astronomy National Collaborative Research Infrastructure Strategy (NCRIS) allocation provided by the Australian Government and managed by Astronomy Australia Limited (AAL).
 * NSF grant AST-1816492.
 
+We also acknowledge the [LOFAR Transients Pipeline (TraP)](https://ascl.net/1412.011) ([Swinbank, et al. 2015](https://ui.adsabs.harvard.edu/abs/2015A%26C....11...25S/abstract)) from which various concepts and design choices have been implemented in the VAST Pipeline.
+
 The developers thank the creators of [SB Admin 2](https://github.com/StartBootstrap/startbootstrap-sb-admin-2) to make the dashboard template freely available.

--- a/docs/help_and_acknowledgements.md
+++ b/docs/help_and_acknowledgements.md
@@ -29,4 +29,6 @@ The VAST Pipeline development was supported by:
 * Software support resources awarded under the Astronomy Data and Computing Services (ADACS) Merit Allocation Program. ADACS is funded from the Astronomy National Collaborative Research Infrastructure Strategy (NCRIS) allocation provided by the Australian Government and managed by Astronomy Australia Limited (AAL).
 * NSF grant AST-1816492.
 
+We also acknowledge the [LOFAR Transients Pipeline (TraP)](https://ascl.net/1412.011) ([Swinbank, et al. 2015](https://ui.adsabs.harvard.edu/abs/2015A%26C....11...25S/abstract)) from which various concepts and design choices have been implemented in the VAST Pipeline.
+
 The developers thank the creators of [SB Admin 2](https://github.com/StartBootstrap/startbootstrap-sb-admin-2) to make the dashboard template freely available.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: >-
   VAST Pipeline platform to enable processing of astronomical sources
   extracted from the ASKAP telescope for radio transient detection science
 site_author: VAST Development Team
+site_url: https://vast-survey.org/vast-pipeline/
 copyright: Copyright &copy; 2020 - 2025 Vast Development Team, University of Sydney - all right reserved
 
 repo_url: https://github.com/askap-vast/vast-pipeline


### PR DESCRIPTION
* Fixes the outdated link to the installation instructions in the README.
* Fixes the URLs to assets for the documentation 404 page by configuring `site_url` in the docs config.

Fixes #541, fixes #542.