### PR TITLE
only read .env if required vars are undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Changed
 
+- Gulp will only read `webinterface/.env` if the required vars are undefined in the current environment [#548](https://github.com/askap-vast/vast-pipeline/pull/548).
+
 #### Fixed
 
 - Fixed outdated installation link in README [#543](https://github.com/askap-vast/vast-pipeline/pull/543).
@@ -20,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#548](https://github.com/askap-vast/vast-pipeline/pull/548): fix: only read .env if required vars are undefined.
 - [#543](https://github.com/askap-vast/vast-pipeline/pull/543): fix, doc: Fix README link and documentation 404 assets.
 
 ## [1.0.0](https://github.com/askap-vast/vast-pipeline/releases/v1.0.0) (2021-05-21)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -129,8 +129,6 @@ function js9MoveGif() {
 }
 
 function js9FixStaticUrl(bc) {
-  let base_url = null
-  let static_url = '/static/'
   // If STATIC_URL isn't in the env, load it from the .env file. We also need BASE_URL
   // but since it's optional it may not be set.
   if (process.env.STATIC_URL === undefined) {
@@ -140,8 +138,8 @@ function js9FixStaticUrl(bc) {
       throw result.error
     }
   }
-  base_url = process.env.BASE_URL || null
-  static_url = process.env.STATIC_URL || '/static/'
+  let base_url = process.env.BASE_URL || null
+  let static_url = process.env.STATIC_URL || '/static/'
   let fileContent = fs.readFileSync(paths.js9Target + '/js9prefs.js', 'utf8')
   let serving_url = (base_url) ? '/' + base_url.split('/').join('') + '/' + static_url.split('/').join('') + '/' : static_url
   return fs.writeFile(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -129,13 +129,20 @@ function js9MoveGif() {
 }
 
 function js9FixStaticUrl(bc) {
-  const result = require('dotenv').config({ 'path': './webinterface/.env' })
-  if (result.error) {
-    throw result.error
+  let base_url = null
+  let static_url = '/static/'
+  // If STATIC_URL isn't in the env, load it from the .env file. We also need BASE_URL
+  // but since it's optional it may not be set.
+  if (process.env.STATIC_URL === undefined) {
+    const result = require('dotenv').config({ 'path': './webinterface/.env' })
+    // note that .config automatically copies the env vars to process.env
+    if (result.error) {
+      throw result.error
+    }
   }
-  let base_url = result.parsed.BASE_URL || null,
-    static_url = result.parsed.STATIC_URL || '/static/',
-    fileContent = fs.readFileSync(paths.js9Target + '/js9prefs.js', 'utf8')
+  base_url = process.env.BASE_URL || null
+  static_url = process.env.STATIC_URL || '/static/'
+  let fileContent = fs.readFileSync(paths.js9Target + '/js9prefs.js', 'utf8')
   let serving_url = (base_url) ? '/' + base_url.split('/').join('') + '/' + static_url.split('/').join('') + '/' : static_url
   return fs.writeFile(
     paths.js9Target + '/js9prefs.js',


### PR DESCRIPTION
Fixes #547
[skip ci]