### PR TITLE
compute ideal source coverage with astropy xmatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Changed
 
+- Reduced the memory footprint for computing the ideal source coverages by sky regions [#555](https://github.com/askap-vast/vast-pipeline/pull/555).
 - Gulp will only read `webinterface/.env` if the required vars are undefined in the current environment [#548](https://github.com/askap-vast/vast-pipeline/pull/548).
 
 #### Fixed
@@ -23,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#555](https://github.com/askap-vast/vast-pipeline/pull/555): fix: compute ideal source coverage with astropy xmatch.
 - [#550](https://github.com/askap-vast/vast-pipeline/pull/550): fix: missing changelog entry
 - [#548](https://github.com/askap-vast/vast-pipeline/pull/548): fix: only read .env if required vars are undefined.
 - [#546](https://github.com/askap-vast/vast-pipeline/pull/546): feat, fix: remove unused imports, and added basic linter during CI/CD.

--- a/vast_pipeline/pipeline/utils.py
+++ b/vast_pipeline/pipeline/utils.py
@@ -17,7 +17,6 @@ import dask.dataframe as dd
 from typing import List, Optional, Dict, Tuple
 from astropy.io import fits
 from astropy.coordinates import SkyCoord, Angle
-from astropy.io import fits
 from django.conf import settings
 from django.contrib.auth.models import User
 from psutil import cpu_count
@@ -29,7 +28,6 @@ from vast_pipeline.utils.utils import (
 from vast_pipeline.models import (
     Band, Image, Run, SkyRegion
 )
-from vast_pipeline.image.utils import on_sky_sep
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Previous implementation required the Cartesian product of every source and sky region be held in memory. Fixes #554.