### PR TITLE
Add TNS external search for sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Added
 
+- Added TNS cone search to the external search results on the source detail page [#557](https://github.com/askap-vast/vast-pipeline/pull/557).
 - Added `site_url` to the mkdocs config so static asset URLs have the correct base URL [#543](https://github.com/askap-vast/vast-pipeline/pull/543).
 - Added basic linter to CI/CD [#546](https://github.com/askap-vast/vast-pipeline/pull/546)
 
@@ -23,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#557](https://github.com/askap-vast/vast-pipeline/pull/557): feat: Add TNS external search for sources.
 - [#550](https://github.com/askap-vast/vast-pipeline/pull/550): fix: missing changelog entry
 - [#548](https://github.com/askap-vast/vast-pipeline/pull/548): fix: only read .env if required vars are undefined.
 - [#546](https://github.com/askap-vast/vast-pipeline/pull/546): feat, fix: remove unused imports, and added basic linter during CI/CD.

--- a/docs/exploringwebsite/sourcepages.md
+++ b/docs/exploringwebsite/sourcepages.md
@@ -123,7 +123,7 @@ If an epoch pairing is significant then they are joined by a line on the graph. 
 
 ### External Search Results Table
 
-This table shows the result of a query to the SIMBAD and NED services for astronomical sources within 1 arcmin of the source location. 
+This table shows the result of a query to the SIMBAD, NED, and TNS services for astronomical sources within 1 arcmin of the source location. 
 Along with the name and coordinate of the matches, the on-sky separation between the source is shown along with the source type.
 
 ### JS9 Viewer Postage Stamps

--- a/docs/gettingstarted/configuration.md
+++ b/docs/gettingstarted/configuration.md
@@ -124,6 +124,10 @@ Shown below is the [`.env.template`](https://github.com/askap-vast/vast-pipeline
     SOCIAL_AUTH_GITHUB_ORG_NAME=fillMeUp
     SOCIAL_AUTH_GITHUB_ADMIN_TEAM=fillMeUp
 
+    # External APIs
+    # TNS_API_KEY= uncomment and fill to use
+    # TNS_USER_AGENT= uncomment and fill to use
+
     # Pipeline
     PIPELINE_WORKING_DIR=pipeline-runs
     FLUX_DEFAULT_MIN_ERROR=0.001
@@ -135,7 +139,7 @@ Shown below is the [`.env.template`](https://github.com/askap-vast/vast-pipeline
     MAX_PIPERUN_IMAGES=200
     ```
 
-The available settings are grouped into three distinct categories:
+The available settings are grouped into 4 distinct categories:
 
 ### Django
 
@@ -155,6 +159,29 @@ Please refer to the [Python Social Auth documentation](https://python-social-aut
 !!! note
     By default the pipeline is set up for authentication using GitHub organizations. Note that switching to teams will require changes to `settings.py`. 
     Please refer to the instructions in the [Python Social Auth documentation](https://python-social-auth.readthedocs.io/en/latest/backends/github.html){:target="_blank"}.
+
+### External APIs
+
+The pipeline website interface supports querying some external APIs, e.g. SIMBAD, NED, VizieR, TNS. Some of these APIs require authentication which are described below.
+
+#### Transient Name Server (TNS)
+
+If you wish to enable TNS cone search results on the [source detail page](../exploringwebsite/sourcepages.md#source-detail-page), you must first obtain an API key for TNS.
+
+1. Create a TNS account at https://www.wis-tns.org/user/register if you do not already have one.
+2. Once logged in, create a bot by navigating to https://www.wis-tns.org/bots and clicking "Add bot" near the top of the table.
+3. Fill in the create bot form. Ensure that you select "Create new API key".
+4. Securely store the API key and paste it into your pipeline `webinterface/.env` file under `TNS_API_KEY`.
+
+    !!! warning
+        Do not lose the API key! It is not possible to retrieve it again past this point.
+
+5. Navigate to your [account page on TNS](https://www.wis-tns.org/user) and copy the User-Agent specification. Paste it into your pipeline `webinterface/.env` file under `TNS_USER_AGENT`.
+
+    !!! example "webinterface/.env"
+        ```console
+        TNS_USER_AGENT='tns_marker{"tns_id": 0000, "type": "user", "name": "your_username"}'
+        ```
 
 ### Pipeline
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,6 +150,7 @@ nav:
           - translators.py: reference/survey/translators.md
         - utils:
           - auth.py: reference/utils/auth.md
+          - external_query.py: reference/utils/external_query.md
           - unit_tags.py: reference/utils/unit_tags.md
           - utils.py: reference/utils/utils.md
           - view.py: reference/utils/view.md

--- a/static/js/datatables-pipeline.js
+++ b/static/js/datatables-pipeline.js
@@ -272,6 +272,8 @@ $(document).ready(function() {
               return '<a href="http://simbad.u-strasbg.fr/simbad/sim-id?Ident=' + row['object_name'] + '" target="_blank">' + row['object_name'] + '</a> (' + row['database'] + ')'
             } else if (row["database"] == "NED") {
               return '<a href="https://ned.ipac.caltech.edu/byname?objname=' + row['object_name'] + '" target="_blank">' + row['object_name'] + '</a> (' + row['database'] + ')'
+            } else if (row["database"] == "TNS") {
+              return '<a href="https://www.wis-tns.org/object/' + row['object_name'] + '" target="_blank">' + row['object_name'] + '</a> (' + row['database'] + ')'
             } else {
               return row['object_name'] + ' (' + row['database'] + ')'
             }

--- a/templates/source_detail.html
+++ b/templates/source_detail.html
@@ -244,7 +244,7 @@
           <div class="table-responsive">
             <table class="table table-sm table-bordered table-striped table-hover" id="externalResultsTable"
               width="100%" cellspacing="0" data-server-side="false"
-              data-ajax="{% url 'vast_pipeline:api_utils-simbad-ned-search' %}?coord={{ source.wavg_ra_hms }}{{ source.wavg_dec_dms }}&format=datatables&keep=otype_long,database">
+              data-ajax="{% url 'vast_pipeline:api_utils-external-search' %}?coord={{ source.wavg_ra_hms }}{{ source.wavg_dec_dms }}&format=datatables&keep=otype_long,database">
               <thead>
                 <tr>
                   <th data-data="object_name">ID</th>

--- a/vast_pipeline/serializers.py
+++ b/vast_pipeline/serializers.py
@@ -193,7 +193,7 @@ class ExternalSearchSerializer(serializers.Serializer):
         help_text="Result origin database, e.g. SIMBAD or NED."
     )
     separation_arcsec = serializers.FloatField()
-    otype = serializers.CharField(help_text="Object type, e.g. QSO.")
+    otype = serializers.CharField(allow_blank=True, help_text="Object type, e.g. QSO.")
     otype_long = serializers.CharField(
         allow_blank=True,
         help_text="Longer form of object type, e.g. quasar. Only supplied for SIMBAD results.",

--- a/vast_pipeline/tests/test_external_query.py
+++ b/vast_pipeline/tests/test_external_query.py
@@ -1,0 +1,35 @@
+from unittest import skipIf
+
+from astropy.coordinates import SkyCoord, Angle
+from django.conf import settings
+from django.test import SimpleTestCase
+
+from vast_pipeline.utils import external_query
+
+
+class ExternalQueryTest(SimpleTestCase):
+    def setUp(self):
+        # coordinates for SN 2018cow
+        self.coord = SkyCoord(
+            ra="16:16:00.220", dec="22:16:04.91", unit="hourangle,deg"
+        )
+        self.radius = Angle("1arcmin")
+
+    def test_simbad(self):
+        simbad_results = external_query.simbad(self.coord, self.radius)
+        self.assertGreaterEqual(len(simbad_results), 2)
+        self.assertEqual(simbad_results[0]["object_name"], "SN 2018cow")
+
+    def test_ned(self):
+        ned_results = external_query.ned(self.coord, self.radius)
+        self.assertGreaterEqual(len(ned_results), 39)
+        self.assertEqual(ned_results[0]["object_name"], "SN 2018cow")
+
+    @skipIf(
+        settings.TNS_API_KEY is None or settings.TNS_USER_AGENT is None,
+        "TNS_API_KEY or TNS_USER_AGENT not defined in settings.",
+    )
+    def test_tns(self):
+        tns_results = external_query.tns(self.coord, self.radius)
+        self.assertGreaterEqual(len(tns_results), 1)
+        self.assertEqual(tns_results[0]["object_name"], "2018cow")

--- a/vast_pipeline/utils/external_query.py
+++ b/vast_pipeline/utils/external_query.py
@@ -5,7 +5,23 @@ from astroquery.simbad import Simbad
 from astroquery.ned import Ned
 
 
-def simbad(coord: SkyCoord, radius: Angle) -> List[Dict[Any, Any]]:
+def simbad(coord: SkyCoord, radius: Angle) -> List[Dict[str, Any]]:
+    """Perform a cone search for sources with SIMBAD.
+
+    Args:
+        coord: the coordinate of the centre of the cone.
+        radius: the radius of the cone in angular units.
+
+    Returns:
+        A list of dicts, where each dict is a query result row with the following keys:
+            object_name: the name of the astronomical object.
+            database: the source of the result, i.e. SIMBAD.
+            separation_arcsec: separation to the query coordinate in arcsec.
+            otype: object type.
+            otype_long: long form of the object type.
+            ra_hms: RA coordinate string in <HH>h<MM>m<SS.SSS>s format.
+            dec_dms: Dec coordinate string in ±<DD>d<MM>m<SS.SSS>s format.
+    """
     CustomSimbad = Simbad()
     CustomSimbad.add_votable_fields(
         "distance_result",
@@ -42,7 +58,23 @@ def simbad(coord: SkyCoord, radius: Angle) -> List[Dict[Any, Any]]:
     return simbad_results_dict_list
 
 
-def ned(coord: SkyCoord, radius: Angle) -> List[Dict[Any, Any]]:
+def ned(coord: SkyCoord, radius: Angle) -> List[Dict[str, Any]]:
+    """Perform a cone search for sources with NED.
+
+    Args:
+        coord: the coordinate of the centre of the cone.
+        radius: the radius of the cone in angular units.
+
+    Returns:
+        A list of dicts, where each dict is a query result row with the following keys:
+            object_name: the name of the astronomical object.
+            database: the source of the result, i.e. NED.
+            separation_arcsec: separation to the query coordinate in arcsec.
+            otype: object type.
+            otype_long: long form of the object type.
+            ra_hms: RA coordinate string in <HH>h<MM>m<SS.SSS>s format.
+            dec_dms: Dec coordinate string in ±<DD>d<MM>m<SS.SSS>s format.
+    """
     # NED API doesn't supply the long-form object types.
     # Copied from https://ned.ipac.caltech.edu/Documents/Guides/Database
     NED_OTYPES = {

--- a/vast_pipeline/utils/external_query.py
+++ b/vast_pipeline/utils/external_query.py
@@ -43,6 +43,73 @@ def simbad(coord: SkyCoord, radius: Angle) -> List[Dict[Any, Any]]:
 
 
 def ned(coord: SkyCoord, radius: Angle) -> List[Dict[Any, Any]]:
+    # NED API doesn't supply the long-form object types.
+    # Copied from https://ned.ipac.caltech.edu/Documents/Guides/Database
+    NED_OTYPES = {
+        "*": "Star or Point Source",
+        "**": "Double star",
+        "*Ass": "Stellar association",
+        "*Cl": "Star cluster",
+        "AbLS": "Absorption line system",
+        "Blue*": "Blue star",
+        "C*": "Carbon star",
+        "EmLS": "Emission line source",
+        "EmObj": "Emission object",
+        "exG*": "Extragalactic star (not a member of an identified galaxy)",
+        "Flare*": "Flare star",
+        "G": "Galaxy",
+        "GammaS": "Gamma ray source",
+        "GClstr": "Cluster of galaxies",
+        "GGroup": "Group of galaxies",
+        "GPair": "Galaxy pair",
+        "GTrpl": "Galaxy triple",
+        "G_Lens": "Lensed image of a galaxy",
+        "HII": "HII region",
+        "IrS": "Infrared source",
+        "MCld": "Molecular cloud",
+        "Neb": "Nebula",
+        "Nova": "Nova",
+        "Other": "Other classification (e.g. comet; plate defect)",
+        "PN": "Planetary nebula",
+        "PofG": "Part of galaxy",
+        "Psr": "Pulsar",
+        "QGroup": "Group of QSOs",
+        "QSO": "Quasi-stellar object",
+        "Q_Lens": "Lensed image of a QSO",
+        "RadioS": "Radio source",
+        "Red*": "Red star",
+        "RfN": "Reflection nebula",
+        "SN": "Supernova",
+        "SNR": "Supernova remnant",
+        "UvES": "Ultraviolet excess source",
+        "UvS": "Ultraviolet source",
+        "V*": "Variable star",
+        "VisS": "Visual source",
+        "WD*": "White dwarf",
+        "WR*": "Wolf-Rayet star",
+        "XrayS": "X-ray source",
+        "!*": "Galactic star",
+        "!**": "Galactic double star",
+        "!*Ass": "Galactic star association",
+        "!*Cl": "Galactic Star cluster",
+        "!Blue*": "Galactic blue star",
+        "!C*": "Galactic carbon star",
+        "!EmObj": "Galactic emission line object",
+        "!Flar*": "Galactic flare star",
+        "!HII": "Galactic HII region",
+        "!MCld": "Galactic molecular cloud",
+        "!Neb": "Galactic nebula",
+        "!Nova": "Galactic nova",
+        "!PN": "Galactic planetary nebula",
+        "!Psr": "Galactic pulsar",
+        "!RfN": "Galactic reflection nebula",
+        "!Red*": "Galactic red star",
+        "!SN": "Galactic supernova",
+        "!SNR": "Galactic supernova remnant",
+        "!V*": "Galactic variable star",
+        "!WD*": "Galactic white dwarf",
+        "!WR*": "Galactic Wolf-Rayet star",
+    }
     ned_result_table = Ned.query_region(coord, radius=radius)
     if ned_result_table is None or len(ned_result_table) == 0:
         ned_results_dict_list = []
@@ -59,7 +126,7 @@ def ned(coord: SkyCoord, radius: Angle) -> List[Dict[Any, Any]]:
                 "DEC": "dec_dms",
             }
         )
-        ned_results_df["otype_long"] = ""  # NED does not supply verbose object types
+        ned_results_df["otype_long"] = ned_results_df.otype.replace(NED_OTYPES)
         # convert NED result separation (arcmin) to arcsec
         ned_results_df["separation_arcsec"] = ned_results_df["separation_arcsec"] * 60
         # convert coordinates to RA (hms) Dec (dms) strings

--- a/vast_pipeline/utils/external_query.py
+++ b/vast_pipeline/utils/external_query.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict, List
+
+from astropy.coordinates import SkyCoord, Angle, Longitude, Latitude
+from astroquery.simbad import Simbad
+from astroquery.ned import Ned
+
+
+def simbad(coord: SkyCoord, radius: Angle) -> List[Dict[Any, Any]]:
+    CustomSimbad = Simbad()
+    CustomSimbad.add_votable_fields(
+        "distance_result",
+        "otype(S)",
+        "otype(V)",
+        "otypes",
+    )
+    simbad_result_table = CustomSimbad.query_region(coord, radius=radius)
+    if simbad_result_table is None:
+        simbad_results_dict_list = []
+    else:
+        simbad_results_df = simbad_result_table[
+            ["MAIN_ID", "DISTANCE_RESULT", "OTYPE_S", "OTYPE_V", "RA", "DEC"]
+        ].to_pandas()
+        simbad_results_df = simbad_results_df.rename(
+            columns={
+                "MAIN_ID": "object_name",
+                "DISTANCE_RESULT": "separation_arcsec",
+                "OTYPE_S": "otype",
+                "OTYPE_V": "otype_long",
+                "RA": "ra_hms",
+                "DEC": "dec_dms",
+            }
+        )
+        simbad_results_df["database"] = "SIMBAD"
+        # convert coordinates to RA (hms) Dec (dms) strings
+        simbad_results_df["ra_hms"] = Longitude(
+            simbad_results_df["ra_hms"], unit="hourangle"
+        ).to_string(unit="hourangle")
+        simbad_results_df["dec_dms"] = Latitude(
+            simbad_results_df["dec_dms"], unit="deg"
+        ).to_string(unit="deg")
+        simbad_results_dict_list = simbad_results_df.to_dict(orient="records")
+    return simbad_results_dict_list
+
+
+def ned(coord: SkyCoord, radius: Angle) -> List[Dict[Any, Any]]:
+    ned_result_table = Ned.query_region(coord, radius=radius)
+    if ned_result_table is None or len(ned_result_table) == 0:
+        ned_results_dict_list = []
+    else:
+        ned_results_df = ned_result_table[
+            ["Object Name", "Separation", "Type", "RA", "DEC"]
+        ].to_pandas()
+        ned_results_df = ned_results_df.rename(
+            columns={
+                "Object Name": "object_name",
+                "Separation": "separation_arcsec",
+                "Type": "otype",
+                "RA": "ra_hms",
+                "DEC": "dec_dms",
+            }
+        )
+        ned_results_df["otype_long"] = ""  # NED does not supply verbose object types
+        # convert NED result separation (arcmin) to arcsec
+        ned_results_df["separation_arcsec"] = ned_results_df["separation_arcsec"] * 60
+        # convert coordinates to RA (hms) Dec (dms) strings
+        ned_results_df["ra_hms"] = Longitude(
+            ned_results_df["ra_hms"], unit="deg"
+        ).to_string(unit="hourangle")
+        ned_results_df["dec_dms"] = Latitude(
+            ned_results_df["dec_dms"], unit="deg"
+        ).to_string(unit="deg")
+        ned_results_df["database"] = "NED"
+        # convert dataframe to dict and replace float NaNs with None for JSON encoding
+        ned_results_dict_list = ned_results_df.sort_values("separation_arcsec").to_dict(
+            orient="records"
+        )
+    return ned_results_dict_list

--- a/vast_pipeline/utils/external_query.py
+++ b/vast_pipeline/utils/external_query.py
@@ -1,26 +1,31 @@
+import json
 from typing import Any, Dict, List
+from urllib.parse import urljoin
 
 from astropy.coordinates import SkyCoord, Angle, Longitude, Latitude
 from astroquery.simbad import Simbad
 from astroquery.ned import Ned
+from django.conf import settings
+import requests
 
 
 def simbad(coord: SkyCoord, radius: Angle) -> List[Dict[str, Any]]:
     """Perform a cone search for sources with SIMBAD.
 
     Args:
-        coord: the coordinate of the centre of the cone.
-        radius: the radius of the cone in angular units.
+        coord: The coordinate of the centre of the cone.
+        radius: The radius of the cone in angular units.
 
     Returns:
         A list of dicts, where each dict is a query result row with the following keys:
-            object_name: the name of the astronomical object.
-            database: the source of the result, i.e. SIMBAD.
-            separation_arcsec: separation to the query coordinate in arcsec.
-            otype: object type.
-            otype_long: long form of the object type.
-            ra_hms: RA coordinate string in <HH>h<MM>m<SS.SSS>s format.
-            dec_dms: Dec coordinate string in ±<DD>d<MM>m<SS.SSS>s format.
+
+        - object_name: the name of the astronomical object.
+        - database: the source of the result, i.e. SIMBAD.
+        - separation_arcsec: separation to the query coordinate in arcsec.
+        - otype: object type.
+        - otype_long: long form of the object type.
+        - ra_hms: RA coordinate string in hms format.
+        - dec_dms: Dec coordinate string in ±dms format.
     """
     CustomSimbad = Simbad()
     CustomSimbad.add_votable_fields(
@@ -62,18 +67,19 @@ def ned(coord: SkyCoord, radius: Angle) -> List[Dict[str, Any]]:
     """Perform a cone search for sources with NED.
 
     Args:
-        coord: the coordinate of the centre of the cone.
-        radius: the radius of the cone in angular units.
+        coord: The coordinate of the centre of the cone.
+        radius: The radius of the cone in angular units.
 
     Returns:
         A list of dicts, where each dict is a query result row with the following keys:
-            object_name: the name of the astronomical object.
-            database: the source of the result, i.e. NED.
-            separation_arcsec: separation to the query coordinate in arcsec.
-            otype: object type.
-            otype_long: long form of the object type.
-            ra_hms: RA coordinate string in <HH>h<MM>m<SS.SSS>s format.
-            dec_dms: Dec coordinate string in ±<DD>d<MM>m<SS.SSS>s format.
+
+        - object_name: the name of the astronomical object.
+        - database: the source of the result, i.e. NED.
+        - separation_arcsec: separation to the query coordinate in arcsec.
+        - otype: object type.
+        - otype_long: long form of the object type.
+        - ra_hms: RA coordinate string in hms format.
+        - dec_dms: Dec coordinate string in ±dms format.
     """
     # NED API doesn't supply the long-form object types.
     # Copied from https://ned.ipac.caltech.edu/Documents/Guides/Database
@@ -174,3 +180,69 @@ def ned(coord: SkyCoord, radius: Angle) -> List[Dict[str, Any]]:
             orient="records"
         )
     return ned_results_dict_list
+
+
+def tns(coord: SkyCoord, radius: Angle) -> List[Dict[str, Any]]:
+    """Perform a cone search for sources with the Transient Name Server (TNS).
+
+    Args:
+        coord: The coordinate of the centre of the cone.
+        radius: The radius of the cone in angular units.
+
+    Returns:
+        A list of dicts, where each dict is a query result row with the following keys:
+
+        - object_name: the name of the transient.
+        - database: the source of the result, i.e. TNS.
+        - separation_arcsec: separation to the query coordinate in arcsec.
+        - otype: object type.
+        - otype_long: long form of the object type. Not given by TNS, will always be
+            an empty string.
+        - ra_hms: RA coordinate string in hms format.
+        - dec_dms: Dec coordinate string in ±dms format.
+    """
+    TNS_API_URL = "https://www.wis-tns.org/api/"
+    headers = {
+        "user-agent": settings.TNS_USER_AGENT,
+    }
+
+    search_dict = {
+        "ra": coord.ra.to_string(unit="hourangle", sep=":", pad=True),
+        "dec": coord.dec.to_string(unit="deg", sep=":", alwayssign=True, pad=True),
+        "radius": str(radius.value),
+        "units": radius.unit.name,
+    }
+    r = requests.post(
+        urljoin(TNS_API_URL, "get/search"),
+        data={"api_key": settings.TNS_API_KEY, "data": json.dumps(search_dict)},
+        headers=headers,
+    )
+    tns_results_dict_list: List[Dict[str, Any]]
+    if r.ok:
+        tns_results_dict_list = r.json()["data"]["reply"]
+        # Get details for each object result. TNS API doesn't support doing this in one
+        # request, so we iterate.
+        for result in tns_results_dict_list:
+            search_dict = {
+                "objname": result["objname"],
+            }
+            r = requests.post(
+                urljoin(TNS_API_URL, "get/object"),
+                data={"api_key": settings.TNS_API_KEY, "data": json.dumps(search_dict)},
+                headers=headers,
+            )
+            if r.ok:
+                object_dict = r.json()["data"]["reply"]
+                object_coord = SkyCoord(
+                    ra=object_dict["radeg"], dec=object_dict["decdeg"], unit="deg"
+                )
+                result["otype"] = object_dict["object_type"]["name"]
+                if result["otype"] is None:
+                    result["otype"] = ""
+                result["otype_long"] = ""
+                result["separation_arcsec"] = coord.separation(object_coord).arcsec
+                result["ra_hms"] = object_coord.ra.to_string(unit="hourangle")
+                result["dec_dms"] = object_coord.dec.to_string(unit="deg")
+                result["database"] = "TNS"
+                result["object_name"] = object_dict["objname"]
+    return tns_results_dict_list

--- a/vast_pipeline/views.py
+++ b/vast_pipeline/views.py
@@ -2054,8 +2054,9 @@ class UtilitiesSet(ViewSet):
 
         simbad_results = external_query.simbad(coord, radius)
         ned_results = external_query.ned(coord, radius)
+        tns_results = external_query.tns(coord, radius)
 
-        results = simbad_results + ned_results
+        results = simbad_results + ned_results + tns_results
         serializer = ExternalSearchSerializer(data=results, many=True)
         serializer.is_valid(raise_exception=True)
         return Response(serializer.data)

--- a/webinterface/.env.template
+++ b/webinterface/.env.template
@@ -18,6 +18,10 @@ SOCIAL_AUTH_GITHUB_SECRET=fillMeUp
 SOCIAL_AUTH_GITHUB_ORG_NAME=fillMeUp
 SOCIAL_AUTH_GITHUB_ADMIN_TEAM=fillMeUp
 
+# External APIs
+# TNS_API_KEY= uncomment and fill to use
+# TNS_USER_AGENT= uncomment and fill to use
+
 # Pipeline
 PIPELINE_WORKING_DIR=pipeline-runs
 FLUX_DEFAULT_MIN_ERROR=0.001

--- a/webinterface/settings.py
+++ b/webinterface/settings.py
@@ -143,6 +143,9 @@ SOCIAL_AUTH_GITHUB_ORG_SCOPE = ['read:org', 'user:email']
 
 CRISPY_TEMPLATE_PACK = "bootstrap4"
 
+TNS_API_KEY = env('TNS_API_KEY', default=None)
+TNS_USER_AGENT = env('TNS_USER_AGENT', default=None)
+
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 


### PR DESCRIPTION
This PR adds cone search results from the [Transient Name Server](https://www.wis-tns.org) to the "External Search Results" table on the source detail page. These results contain cone search results from SIMBAD, NED, and now TNS.

As part of this, the external search functions have been refactored to their own module with the intent of simplifying the implementation of other external providers in the future.

Added documentation for the TNS resolver as it requires an API key.

Added tests for all external search providers using a well known transient source (SN 2018cow).

Closes #498.