### PR TITLE
Fixed UI re-run from errored status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Added
 
+- Added try-except error capture on pre-run checks to correctly assign pipeline run as failed if an error occurs [#576](https://github.com/askap-vast/vast-pipeline/pull/576).
 - Added support for ingesting Selavy catalogues in VOTable (XML) and CSV format [#565](https://github.com/askap-vast/vast-pipeline/pull/565)
 - Added new commands: `initingest` and `ingestimages` [#544](https://github.com/askap-vast/vast-pipeline/pull/544)
 - Added TNS cone search to the external search results on the source detail page [#557](https://github.com/askap-vast/vast-pipeline/pull/557).
@@ -23,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Fixed logic for full re-run requirement when UI run is being re-run from an error status [#576](https://github.com/askap-vast/vast-pipeline/pull/576).
 - Fixed a regression from pandas=1.3.0 that caused non-numeric columns to be dropped after a groupby sum operation [#567](https://github.com/askap-vast/vast-pipeline/pull/567).
 - Fixed permission error for regular users when trying to launch an initialised run [#563](https://github.com/askap-vast/vast-pipeline/pull/563).
 - Fixed outdated installation link in README [#543](https://github.com/askap-vast/vast-pipeline/pull/543).
@@ -31,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#576](https://github.com/askap-vast/vast-pipeline/pull/576): fix: Fixed UI re-run from errored status.
 - [#565](https://github.com/askap-vast/vast-pipeline/pull/565): feat: added support for reading selavy VOTables and CSVs.
 - [#567](https://github.com/askap-vast/vast-pipeline/pull/567): fix: fixed pandas=1.3.0 groupby sum regression.
 - [#563](https://github.com/askap-vast/vast-pipeline/pull/563): fix: fixed launch run user permission bug.

--- a/vast_pipeline/management/commands/runpipeline.py
+++ b/vast_pipeline/management/commands/runpipeline.py
@@ -123,143 +123,162 @@ def run_pipe(
     # parquets and proceed.
     # C. Additional Run on errored run: Do not backup parquets, just delete
     # current.
+    # D. Running on initialised run that errored and is still the init run.
 
     # Flag on the pipeline object on whether the addition mode is on or off.
     pipeline.add_mode = False
     pipeline.previous_parquets = {}
+    prev_config_exists = False
 
-    if not flag_exist:
-        # check for and remove any present .parquet (and .arrow) files
-        parquets = (
-            glob.glob(os.path.join(p_run.path, "*.parquet"))
-            # TODO Remove arrow when vaex support is dropped.
-            + glob.glob(os.path.join(p_run.path, "*.arrow"))
-            + glob.glob(os.path.join(p_run.path, "*.bak"))
-        )
-        for parquet in parquets:
-            os.remove(parquet)
-    else:
-        # Check if the status is already running or queued. Exit if this is the
-        # case.
-        if p_run.status in ['RUN', 'RES']:
-            logger.error(
-                "The pipeline run requested to process already has a running"
-                " or restoring status! Performing no actions. Exiting."
-            )
-            return True
-
-        # Check for an error status and whether any previous config file
-        # exists - if it doesn't exist it means the run has failed during
-        # the first run. In this case we want to clear anything that has gone
-        # on before so to do that `complete-rerun` mode is activated.
-        if p_run.status == "ERR" and not os.path.isfile(
-            os.path.join(p_run.path, "config_prev.yaml")
-        ):
-            full_rerun = True
-
-        # Backup the previous run config
-        if os.path.isfile(
-            os.path.join(p_run.path, 'config_prev.yaml')
-        ):
-            shutil.copy(
-                os.path.join(p_run.path, 'config_prev.yaml'),
-                os.path.join(p_run.path, 'config.yaml.bak')
-            )
-
-        # Check if the run has only been initialised, if so we don't want to do
-        # any previous run checks or cleaning.
-        if p_run.status == 'INI':
-            initial_run = True
-        # check if coming from UI
-        elif cli is False and prev_ui_status == 'INI':
-            initial_run = True
-        else:
-            initial_run = False
-
-        if initial_run is False:
+    try:
+        if not flag_exist:
+            # check for and remove any present .parquet (and .arrow) files
             parquets = (
                 glob.glob(os.path.join(p_run.path, "*.parquet"))
-                # TODO Remove arrow when arrow files are no longer needed.
+                # TODO Remove arrow when vaex support is dropped.
                 + glob.glob(os.path.join(p_run.path, "*.arrow"))
+                + glob.glob(os.path.join(p_run.path, "*.bak"))
             )
-
-            if full_rerun:
-                if p_run.status == 'END':
-                    backup_parquets(p_run.path)
-                logger.info(
-                    'Cleaning up pipeline run before re-process data'
+            for parquet in parquets:
+                os.remove(parquet)
+        else:
+            # Check if the status is already running or queued. Exit if this is
+            # the case.
+            if p_run.status in ['RUN', 'RES']:
+                logger.error(
+                    "The pipeline run requested to process already has a "
+                    "running or restoring status! Performing no actions. "
+                    "Exiting."
                 )
-                p_run.image_set.clear()
+                return True
 
-                logger.info(
-                    'Cleaning up forced measurements before re-process data'
+            # Check if there is a previous run config and back up if so
+            if os.path.isfile(
+                os.path.join(p_run.path, 'config_prev.yaml')
+            ):
+                prev_config_exists = True
+                shutil.copy(
+                    os.path.join(p_run.path, 'config_prev.yaml'),
+                    os.path.join(p_run.path, 'config.yaml.bak')
                 )
-                remove_forced_meas(p_run.path)
+            logger.debug(f'config_prev.yaml exists: {prev_config_exists}')
 
-                for parquet in parquets:
-                    os.remove(parquet)
+            # Check for an error status and whether any previous config file
+            # exists - if it doesn't exist it means the run has failed during
+            # the first run. In this case we want to clear anything that has
+            # gone on before so to do that `complete-rerun` mode is activated.
+            if not prev_config_exists:
+                if cli and p_run.status == "ERR":
+                    full_rerun = True
+                elif not cli and prev_ui_status == "ERR":
+                    full_rerun = True
+            logger.debug(f'Full re-run: {full_rerun}')
 
-                # remove bak files
-                bak_files = glob.glob(os.path.join(p_run.path, "*.bak"))
-                if bak_files:
-                    for bf in bak_files:
-                        os.remove(bf)
-
-                # remove previous config if it exists
-                if os.path.isfile(os.path.join(p_run.path, 'config_prev.yaml')):
-                    os.remove(os.path.join(p_run.path, 'config_prev.yaml'))
-
-                # reset epoch_based flag
-                with transaction.atomic():
-                    p_run.epoch_based = False
-                    p_run.save()
+            # Check if the run has only been initialised, if so we don't want
+            # to do any previous run checks or cleaning.
+            if p_run.status == 'INI':
+                initial_run = True
+            # check if coming from UI
+            elif cli is False and prev_ui_status == 'INI':
+                initial_run = True
             else:
-                # Before parquets are started to be copied and backed up, a
-                # check is run to see if anything has actually changed in
-                # the config
-                config_diff = pipeline.config.check_prev_config_diff()
-                if config_diff:
+                initial_run = False
+
+            if initial_run is False:
+                parquets = (
+                    glob.glob(os.path.join(p_run.path, "*.parquet"))
+                    # TODO Remove arrow when arrow files are no longer needed.
+                    + glob.glob(os.path.join(p_run.path, "*.arrow"))
+                )
+
+                if full_rerun:
+                    if p_run.status == 'END':
+                        backup_parquets(p_run.path)
                     logger.info(
-                        "The config file has either not changed since the"
-                        " previous run or other settings have changed such"
-                        " that a new or complete re-run should be performed"
-                        " instead. Performing no actions. Exiting."
+                        'Cleaning up pipeline run before re-process data'
                     )
-                    os.remove(os.path.join(p_run.path, 'config_temp.yaml'))
-                    pipeline.set_status(p_run, 'END')
+                    p_run.image_set.clear()
 
-                    return True
-
-                if pipeline.config.epoch_based != p_run.epoch_based:
                     logger.info(
-                        "The 'epoch based' setting has changed since the"
-                        " previous run. A complete re-run is required if"
-                        " changing to epoch based mode or vice versa."
+                        'Cleaning up forced measurements before re-process data'
                     )
-                    os.remove(os.path.join(p_run.path, 'config_temp.yaml'))
-                    pipeline.set_status(p_run, 'END')
-                    return True
+                    remove_forced_meas(p_run.path)
 
-                if cli and p_run.status == 'END':
-                    backup_parquets(p_run.path)
-                elif not cli and prev_ui_status == 'END':
-                    backup_parquets(p_run.path)
+                    for parquet in parquets:
+                        os.remove(parquet)
 
-                pipeline.add_mode = True
-                for i in [
-                    'images', 'associations', 'sources', 'relations',
-                    'measurement_pairs'
-                ]:
-                    pipeline.previous_parquets[i] = os.path.join(
-                        p_run.path, f'{i}.parquet.bak')
+                    # remove bak files
+                    bak_files = glob.glob(os.path.join(p_run.path, "*.bak"))
+                    if bak_files:
+                        for bf in bak_files:
+                            os.remove(bf)
+
+                    # remove previous config if it exists
+                    if prev_config_exists:
+                        os.remove(os.path.join(p_run.path, 'config_prev.yaml'))
+
+                    # reset epoch_based flag
+                    with transaction.atomic():
+                        p_run.epoch_based = False
+                        p_run.save()
+                else:
+                    # Before parquets are started to be copied and backed up, a
+                    # check is run to see if anything has actually changed in
+                    # the config
+                    config_diff = pipeline.config.check_prev_config_diff()
+                    if config_diff:
+                        logger.info(
+                            "The config file has either not changed since the"
+                            " previous run or other settings have changed such"
+                            " that a new or complete re-run should be performed"
+                            " instead. Performing no actions. Exiting."
+                        )
+                        os.remove(os.path.join(p_run.path, 'config_temp.yaml'))
+                        pipeline.set_status(p_run, 'END')
+
+                        return True
+
+                    if pipeline.config.epoch_based != p_run.epoch_based:
+                        logger.info(
+                            "The 'epoch based' setting has changed since the"
+                            " previous run. A complete re-run is required if"
+                            " changing to epoch based mode or vice versa."
+                        )
+                        os.remove(os.path.join(p_run.path, 'config_temp.yaml'))
+                        pipeline.set_status(p_run, 'END')
+                        return True
+
+                    if cli and p_run.status == 'END':
+                        backup_parquets(p_run.path)
+                    elif not cli and prev_ui_status == 'END':
+                        backup_parquets(p_run.path)
+
+                    pipeline.add_mode = True
+                    for i in [
+                        'images', 'associations', 'sources', 'relations',
+                        'measurement_pairs'
+                    ]:
+                        pipeline.previous_parquets[i] = os.path.join(
+                            p_run.path, f'{i}.parquet.bak')
+    except Exception as e:
+        logger.error('Unexpected error occurred in pre-run steps!')
+        pipeline.set_status(p_run, 'ERR')
+        logger.exception('Processing error:\n%s', e)
+        raise CommandError(f'Processing error:\n{e}')
 
     if pipeline.config["run"]["suppress_astropy_warnings"]:
         warnings.simplefilter("ignore", category=AstropyWarning)
 
     logger.info("VAST Pipeline version: %s", pipeline_version)
-    logger.info("Source finder: %s", pipeline.config["measurements"]["source_finder"])
+    logger.info(
+        "Source finder: %s",
+        pipeline.config["measurements"]["source_finder"]
+    )
     logger.info("Using pipeline run '%s'", pipeline.name)
-    logger.info("Source monitoring: %s", pipeline.config["source_monitoring"]["monitor"])
+    logger.info(
+        "Source monitoring: %s",
+        pipeline.config["source_monitoring"]["monitor"]
+    )
 
     # log the list of input data files for posterity
     input_image_list = [


### PR DESCRIPTION
- Added check for UI error status.
- Added try/except to catch any errors in the pre-check portion of run_pipe.
- Added extra debug logging lines.

Fixes #575.

For example, before I applied the fix, the original error is now reported in the log and the pipeline run is set to `Error` status instead of being left hanging.
```
2021-09-08 12:44:51,354 runpipeline DEBUG Copying temp config file.
2021-09-08 12:44:51,414 runpipeline DEBUG config_prev.yaml exists: False
2021-09-08 12:44:51,414 runpipeline DEBUG Full re-run: False
2021-09-08 12:44:51,416 runpipeline ERROR Unexpected error occurred in pre-run steps!
2021-09-08 12:44:51,434 runpipeline ERROR Processing error:
[Errno 2] No such file or directory: '/Users/adam/GitHub/vast-pipeline/pipeline-runs/test-data-ui/config_prev.yaml'
Traceback (most recent call last):
  File "/Users/adam/GitHub/vast-pipeline/vast_pipeline/management/commands/runpipeline.py", line 228, in run_pipe
    config_diff = pipeline.config.check_prev_config_diff()
  File "/Users/adam/GitHub/vast-pipeline/vast_pipeline/pipeline/config.py", line 522, in check_prev_config_diff
    label="previous run config",
  File "/Users/adam/GitHub/vast-pipeline/vast_pipeline/pipeline/config.py", line 254, in from_file
    with open(yaml_path) as fh:
FileNotFoundError: [Errno 2] No such file or directory: '/Users/adam/GitHub/vast-pipeline/pipeline-runs/test-data-ui/config_prev.yaml'
```