### PR TITLE
Clean up m2m related objects when deleting a run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
-- Fixed removal of image and sky region objects when a run is deleted [#585]((https://github.com/askap-vast/vast-pipeline/pull/585).
+- Fixed removal of image and sky region objects when a run is deleted [#585](https://github.com/askap-vast/vast-pipeline/pull/585).
 - Fixed testing pandas equal deprecation warning [#580](https://github.com/askap-vast/vast-pipeline/pull/580).
 - Fixed restore run relations issue [#580](https://github.com/askap-vast/vast-pipeline/pull/580).
 - Fixed logic for full re-run requirement when UI run is being re-run from an error status [#576](https://github.com/askap-vast/vast-pipeline/pull/576).
@@ -53,7 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
-- [#585]((https://github.com/askap-vast/vast-pipeline/pull/585): fix: Clean up m2m related objects when deleting a run.
+- [#585](https://github.com/askap-vast/vast-pipeline/pull/585): fix: Clean up m2m related objects when deleting a run.
 - [#583](https://github.com/askap-vast/vast-pipeline/pull/583): fix: remove unique constraint from Measurement.name.
 - [#580](https://github.com/askap-vast/vast-pipeline/pull/580): feat, fix, doc: Added UI run action buttons.
 - [#576](https://github.com/askap-vast/vast-pipeline/pull/576): fix: Fixed UI re-run from errored status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Fixed removal of image and sky region objects when a run is deleted [#585]((https://github.com/askap-vast/vast-pipeline/pull/585).
 - Fixed testing pandas equal deprecation warning [#580](https://github.com/askap-vast/vast-pipeline/pull/580).
 - Fixed restore run relations issue [#580](https://github.com/askap-vast/vast-pipeline/pull/580).
 - Fixed logic for full re-run requirement when UI run is being re-run from an error status [#576](https://github.com/askap-vast/vast-pipeline/pull/576).
@@ -52,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#585]((https://github.com/askap-vast/vast-pipeline/pull/585): fix: Clean up m2m related objects when deleting a run.
 - [#583](https://github.com/askap-vast/vast-pipeline/pull/583): fix: remove unique constraint from Measurement.name.
 - [#580](https://github.com/askap-vast/vast-pipeline/pull/580): feat, fix, doc: Added UI run action buttons.
 - [#576](https://github.com/askap-vast/vast-pipeline/pull/576): fix: Fixed UI re-run from errored status.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,6 +168,7 @@ nav:
         - models.py: reference/models.md
         - plots.py: reference/plots.md
         # - serializers.py: reference/serializers.md
+        - signals.py: reference/signals.md
         - urls.py: reference/urls.md
         # - views.py: reference/views.md
 

--- a/vast_pipeline/apps.py
+++ b/vast_pipeline/apps.py
@@ -4,3 +4,7 @@ from django.apps import AppConfig
 class PipelineConfig(AppConfig):
     """Class representing the configuration for the vast_pipeline app."""
     name = 'vast_pipeline'
+
+    def ready(self):
+        # import the signals to register them with the application
+        import vast_pipeline.signals  # noqa: F401

--- a/vast_pipeline/apps.py
+++ b/vast_pipeline/apps.py
@@ -5,6 +5,9 @@ class PipelineConfig(AppConfig):
     """Class representing the configuration for the vast_pipeline app."""
     name = 'vast_pipeline'
 
-    def ready(self):
+    def ready(self) -> None:
+        """Initialization tasks performed as soon as the app registry is populated.
+        See <https://docs.djangoproject.com/en/3.1/ref/applications/#django.apps.AppConfig.ready>.
+        """
         # import the signals to register them with the application
         import vast_pipeline.signals  # noqa: F401

--- a/vast_pipeline/signals.py
+++ b/vast_pipeline/signals.py
@@ -1,0 +1,36 @@
+import logging
+from django.db.models import Count
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
+from vast_pipeline.models import Run, Image, SkyRegion
+
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(pre_delete, sender=Run, dispatch_uid="delete_orphans_for_run")
+def delete_orphans_for_run(sender, instance: Run, using, **kwargs):
+    """Delete any Image and SkyRegion objects that would be orphaned by deleting the
+    given Run.
+    """
+    image_orphans = (
+        Image.objects.annotate(num_runs=Count("run"))
+        .filter(run=instance, num_runs=1)
+    )
+    n_obj_deleted, deleted_dict = image_orphans.delete()
+    logger.info(
+        "Deleted %d objects: %s",
+        n_obj_deleted,
+        ", ".join([f"{model}: {n}" for model, n in deleted_dict.items()]),
+    )
+
+    skyreg_orphans = (
+        SkyRegion.objects.annotate(num_runs=Count("run"))
+        .filter(run=instance, num_runs=1)
+    )
+    n_obj_deleted, deleted_dict = skyreg_orphans.delete()
+    logger.info(
+        "Deleted %d objects: %s",
+        n_obj_deleted,
+        ", ".join([f"{model}: {n}" for model, n in deleted_dict.items()]),
+    )

--- a/vast_pipeline/signals.py
+++ b/vast_pipeline/signals.py
@@ -1,4 +1,7 @@
+"""Functions that are executed upon receiving an application signal."""
 import logging
+from typing import Type
+
 from django.db.models import Count
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
@@ -9,9 +12,18 @@ logger = logging.getLogger(__name__)
 
 
 @receiver(pre_delete, sender=Run, dispatch_uid="delete_orphans_for_run")
-def delete_orphans_for_run(sender, instance: Run, using, **kwargs):
+def delete_orphans_for_run(sender: Type[Run], instance: Run, using: str, **kwargs) -> None:
     """Delete any Image and SkyRegion objects that would be orphaned by deleting the
-    given Run.
+    given Run. Expects to recieve the arguments sent by the pre_delete signal. See
+    <https://docs.djangoproject.com/en/3.1/ref/signals/#pre-delete>.
+
+    Args:
+        sender:
+            Model class that sent the signal.
+        instance:
+            Model instance to be deleted.
+        using:
+            Database alias.
     """
     image_orphans = (
         Image.objects.annotate(num_runs=Count("run"))

--- a/vast_pipeline/tests/test_clearpiperun.py
+++ b/vast_pipeline/tests/test_clearpiperun.py
@@ -1,0 +1,132 @@
+import os
+from typing import Dict
+
+from django.conf import settings as s
+from django.test import TestCase, override_settings
+from django.utils import timezone
+from django.core.management import call_command
+
+from vast_pipeline.models import Run, Image, Band, SkyRegion
+
+
+TEST_ROOT = os.path.join(s.BASE_DIR, "vast_pipeline", "tests")
+
+
+@override_settings(
+    PIPELINE_WORKING_DIR=os.path.join(TEST_ROOT, "pipeline-runs"),
+)
+class ClearPipelineRunTest(TestCase):
+    band: Band
+    run_1: Run
+    run_2: Run
+    skyregs: Dict[str, SkyRegion]
+    images: Dict[str, Image]
+
+    @classmethod
+    def setUpTestData(cls):
+        default_image_kwargs = dict(
+            measurements_path="",
+            polarisation="I",
+            path="",
+            datetime=timezone.now(),
+            jd=0.0,
+            ra=0.0,
+            dec=0.0,
+            fov_bmaj=0.0,
+            fov_bmin=0.0,
+            physical_bmaj=0.0,
+            physical_bmin=0.0,
+            radius_pixels=0.0,
+            beam_bmaj=0.0,
+            beam_bmin=0.0,
+            beam_bpa=0.0,
+            rms_median=0.0,
+            rms_min=0.0,
+            rms_max=0.0,
+        )
+        default_skyreg_kwargs = dict(
+            centre_ra=0.0,
+            centre_dec=0.0,
+            width_ra=0.0,
+            width_dec=0.0,
+            xtr_radius=0.0,
+            x=0.0,
+            y=0.0,
+            z=0.0,
+        )
+        # Create test objects:
+        #   - 2 Runs
+        #   - 3 SkyRegions
+        #   - 4 Images
+        # run_1 contains 3 images: image_a1, image_b1, image_a2.
+        # run_2 contains 2 images: image_b1, image_c1.
+        # The letter suffix indicates the sky region, e.g. image_a1 is in sky region a.
+
+        # create a band
+        cls.band = Band.objects.create(name="band", frequency=887, bandwidth=128)
+        # create runs
+        cls.run_1 = Run.objects.create(name="run_1", path="run_1")
+        cls.run_2 = Run.objects.create(name="run_2", path="run_2")
+        # create sky regions
+        cls.skyregs = {
+            k: SkyRegion.objects.create(**default_skyreg_kwargs)
+            for k in ("a", "b", "c")
+        }
+        # create some images
+        cls.images = {
+            f"{k}1": Image.objects.create(
+                band=cls.band,
+                skyreg=skyreg,
+                name=f"image_{k}1",
+                **default_image_kwargs,
+            )
+            for k, skyreg in cls.skyregs.items()
+        }
+        cls.images["a2"] = Image.objects.create(
+            band=cls.band,
+            skyreg=cls.skyregs["a"],
+            name="image_a2",
+            **default_image_kwargs,
+        )
+        cls.images["a1"].run.add(cls.run_1)
+        cls.images["a2"].run.add(cls.run_1)
+        cls.images["b1"].run.add(cls.run_1)
+        cls.images["b1"].run.add(cls.run_2)
+        cls.images["c1"].run.add(cls.run_2)
+
+        cls.skyregs["a"].run.add(cls.run_1)
+        cls.skyregs["b"].run.add(cls.run_1)
+        cls.skyregs["b"].run.add(cls.run_2)
+        cls.skyregs["c"].run.add(cls.run_2)
+
+    def test_data(self):
+        """Check that the object relationships exist as expected.
+        """
+        self.assertEqual(Image.objects.filter(run=self.run_1).count(), 3)
+        self.assertEqual(Image.objects.filter(run=self.run_2).count(), 2)
+
+        self.assertEqual(SkyRegion.objects.filter(run=self.run_1).count(), 2)
+        self.assertEqual(SkyRegion.objects.filter(run=self.run_2).count(), 2)
+
+    def test_clearpiperun(self):
+        """Delete a run and check that the appropriate objects are also deleted.
+        """
+        # delete run_1
+        call_command("clearpiperun", self.run_1.name)
+
+        # ensure the images and sky regions that were only used in run_1 are deleted
+        with self.assertRaises(Image.DoesNotExist):
+            _ = Image.objects.get(name="image_a1")
+        with self.assertRaises(Image.DoesNotExist):
+            _ = Image.objects.get(name="image_a2")
+        with self.assertRaises(SkyRegion.DoesNotExist):
+            _ = SkyRegion.objects.get(pk=self.skyregs["a"].pk)
+        # ensure the images and sky regions that were used in both run_1 and run_2 remain
+        _ = Image.objects.get(name="image_b1")
+        _ = SkyRegion.objects.get(pk=self.skyregs["b"].pk)
+
+        # delete run_2
+        call_command("clearpiperun", self.run_2.name)
+        # ensure no images nor sky regions remain
+        self.assertEqual(Image.objects.count(), 0)
+        self.assertEqual(SkyRegion.objects.count(), 0)


### PR DESCRIPTION
Adds a function that is called just before a Run object is to be deleted that deletes all Image and SkyRegion objects that would be orphaned after deleting the Run.
Fixes #584