### PR TITLE
change cutout endpoint to use measurement ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Fixed measurement FITS cutout bug [#588](https://github.com/askap-vast/vast-pipeline/pull/588).
 - Fixed removal of image and sky region objects when a run is deleted [#585](https://github.com/askap-vast/vast-pipeline/pull/585).
 - Fixed testing pandas equal deprecation warning [#580](https://github.com/askap-vast/vast-pipeline/pull/580).
 - Fixed restore run relations issue [#580](https://github.com/askap-vast/vast-pipeline/pull/580).
@@ -53,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#588](https://github.com/askap-vast/vast-pipeline/pull/588): fix: change cutout endpoint to use measurement ID.
 - [#585](https://github.com/askap-vast/vast-pipeline/pull/585): fix: Clean up m2m related objects when deleting a run.
 - [#583](https://github.com/askap-vast/vast-pipeline/pull/583): fix: remove unique constraint from Measurement.name.
 - [#580](https://github.com/askap-vast/vast-pipeline/pull/580): feat, fix, doc: Added UI run action buttons.

--- a/templates/measurement_detail.html
+++ b/templates/measurement_detail.html
@@ -322,7 +322,7 @@
       addBaseUrl = (url) => baseUrl == null ? url : '/' + baseUrl + url;
       var measurement = JSON.parse(document.getElementById("data-js9").textContent);
       JS9.Load(
-        addBaseUrl('/cutout/' + measurement.name + '/large'), {
+        addBaseUrl('/cutout/' + measurement.id + '/large'), {
           scalemin: -0.001,
           scalemax: 0.004,
           color: 'gray',

--- a/templates/source_detail.html
+++ b/templates/source_detail.html
@@ -488,7 +488,7 @@
     return new Promise(resolve => {
       JS9.Load(
         addBaseUrl('/cutout/' + imageName + '/large'), {
-          id: imageName,
+          id: imageName.toString(),
           scalemin: -0.001,
           scalemax: 0.002,
           color: 'gray',
@@ -532,7 +532,7 @@
     // load all images and wait until they're all done
     await Promise.all(measurementData.map((measurement, i) => {
       var displayId = "JS9_" + (i + 1);
-      return loadFitsImage(measurement.name, displayId);
+      return loadFitsImage(measurement.id, displayId);
     }));
     JS9.SyncImages(); // sync panning between images
     focusOnSource(4.0);

--- a/vast_pipeline/urls.py
+++ b/vast_pipeline/urls.py
@@ -50,8 +50,8 @@ urlpatterns = [
         kwargs={"tag_model": Source.tags.tag_model},
         name="source_tags_autocomplete",
     ),
-    path('cutout/<str:measurement_name>/', views.ImageCutout.as_view(), name='cutout'),
-    path('cutout/<str:measurement_name>/<str:size>/', views.ImageCutout.as_view(), name='cutout'),
+    path('cutout/<int:measurement_id>/', views.ImageCutout.as_view(), name='cutout'),
+    path('cutout/<int:measurement_id>/<str:size>/', views.ImageCutout.as_view(), name='cutout'),
     path(
         'measurements/<int:image_id>/<ra:ra_deg>,<dec:dec_deg>,<angle:radius_deg>/region/',
         views.MeasurementQuery.as_view(),

--- a/vast_pipeline/views.py
+++ b/vast_pipeline/views.py
@@ -1777,8 +1777,8 @@ class ImageCutout(APIView):
     authentication_classes = [SessionAuthentication, BasicAuthentication]
     permission_classes = [IsAuthenticated]
 
-    def get(self, request, measurement_name, size="normal"):
-        measurement = Measurement.objects.get(name=measurement_name)
+    def get(self, request, measurement_id: int, size: str = "normal"):
+        measurement = Measurement.objects.get(id=measurement_id)
         image_hdu: fits.PrimaryHDU = fits.open(measurement.image.path)[0]
         coord = SkyCoord(ra=measurement.ra, dec=measurement.dec, unit="deg")
         sizes = {


### PR DESCRIPTION
Replaces using the non-unique measurement name. Fixes #587.
[skip ci] as no test covers the cutouts.