### PR TITLE
Update detail page titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Stopped JS9 from changing the page titles [#597](https://github.com/askap-vast/vast-pipeline/pull/597).
 - Fixed regression issues with pandas 1.4 [#586](https://github.com/askap-vast/vast-pipeline/pull/586).
 - Fixed config being copied before run was confirmed to actually go ahead for existing runs [#595](https://github.com/askap-vast/vast-pipeline/pull/595).
 - Fixed forced measurements being removed from associations during the restore run process [#600](https://github.com/askap-vast/vast-pipeline/pull/600).
@@ -67,6 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#597](https://github.com/askap-vast/vast-pipeline/pull/597): fix: Update detail page titles.
 - [#586](https://github.com/askap-vast/vast-pipeline/pull/586): feat, dep, doc: Add an eta-v analysis page for the source query.
 - [#595](https://github.com/askap-vast/vast-pipeline/pull/595): fix: Add date and time stamp to log files.
 - [#600](https://github.com/askap-vast/vast-pipeline/pull/600): fix: Fixed restore run forced measurements associations.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,6 +105,7 @@ function js9Config(bc) {
     "wcs",
     "zoom"
   ]
+  js9Config.globalOpts.updateTitlebar = false
   js9Config.textColorOpts = { "info": "#000064" }
 
   let outConfig = 'var JS9Prefs = ' + JSON.stringify(js9Config)

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,9 @@
   <meta name="description" content="VAST Pipeline WebApp for processing the images from the ASKAP Telescope and detecting transient sources">
   <meta name="author" content="VAST Developement Team">
 
+  {% block title %}
   <title>VAST Pipeline</title>
+  {% endblock title %}
 
   <!-- VAST icon -->
   <link rel="shortcut icon" type="image/png" href="{% static 'img/favicon.png' %}"/>

--- a/templates/image_detail.html
+++ b/templates/image_detail.html
@@ -4,6 +4,10 @@
 {% load humanize %}
 {% load unit_tags %}
 
+{% block title %}
+<title>VAST Pipeline: Image ID {{ image.id }}</title>
+{% endblock title %}
+
 {% block head %}
 
 <link href="{% static 'vendor/datatables/dataTables.bootstrap4.min.css' %}" rel="stylesheet">

--- a/templates/measurement_detail.html
+++ b/templates/measurement_detail.html
@@ -4,6 +4,10 @@
 
 {% load unit_tags %}
 
+{% block title %}
+<title>VAST Pipeline: Measurement ID {{ measurement.id }}</title>
+{% endblock title %}
+
 {% block head %}
 
 <link rel="stylesheet" href="{% static 'vendor/js9/js9-allinone.css' %}" />

--- a/templates/run_detail.html
+++ b/templates/run_detail.html
@@ -2,6 +2,9 @@
 {% load static %}
 {% load humanize %}
 
+{% block title %}
+<title>VAST Pipeline: Run ID {{ p_run.id }}</title>
+{% endblock title %}
 
 {% block head %}
 

--- a/templates/source_detail.html
+++ b/templates/source_detail.html
@@ -5,6 +5,10 @@
 
 {% load unit_tags %}
 
+{% block title %}
+<title>VAST Pipeline: Source ID {{ source.id }}</title>
+{% endblock title %}
+
 {% block head %}
 
 <link rel='stylesheet' href='https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.css' />


### PR DESCRIPTION
Adds the object IDs to the detail page titles (the text set by `<title>` tags). e.g. the title for a source detail page is now "VAST Pipeline: Source ID x" where x is the source ID number. The measurement, run, and image detail page titles have also been updated.

Also includes a new JS9 config setting to prevent JS9 displays from modifying the page titles.