### PR TITLE
Pair metrics hover tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Added
 
+- Added the 0-based index of each measurement to the image cutout card headers [#625](https://github.com/askap-vast/vast-pipeline/pull/625).
+- Added Bokeh hover tooltip to measurement pair graph to display pair metrics [#625](https://github.com/askap-vast/vast-pipeline/pull/625).
 - Added eta-V plot analysis page along with documentation [#586](https://github.com/askap-vast/vast-pipeline/pull/586).
 - Added thumbnails to light curve tooltips [#586](https://github.com/askap-vast/vast-pipeline/pull/586).
 - Added logfile dropdown selection to run detail page [#595](https://github.com/askap-vast/vast-pipeline/pull/595).
@@ -71,6 +73,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#625](https://github.com/askap-vast/vast-pipeline/pull/625): feat: Pair metrics hover tooltip.
 - [#623](https://github.com/askap-vast/vast-pipeline/pull/623): fix: fixed NED links.
 - [#616](https://github.com/askap-vast/vast-pipeline/pull/616): fix: added error handling to external queries.
 - [#614](https://github.com/askap-vast/vast-pipeline/pull/614): feat: Refactored add to favourites button to avoid refresh.

--- a/docs/exploringwebsite/sourcedetail.md
+++ b/docs/exploringwebsite/sourcedetail.md
@@ -42,8 +42,8 @@ It also contains a thumbnail image preview of the respective measurement.
 
 ## Two-epoch Node Graph
 
-The node graph is a visual representation of what two-epoch pairings have significant variability metric values. 
-If an epoch pairing is significant then they are joined by a line on the graph. Hovering over the line will highlight the epoch pairing on the light curve plot.
+The node graph is a visual representation of what two-epoch pairings have significant variability metric values.
+If an epoch pairing is significant then they are joined by a line on the graph. Hovering over the line will display the pair metrics for the selected flux type (peak or integrated) and highlight the epoch pairing on the light curve plot.
 
 ## External Search Results Table
 

--- a/templates/source_detail.html
+++ b/templates/source_detail.html
@@ -285,6 +285,7 @@
           {% for measurement in datatables.0.dataQuery %}
           <div class="card">
             <div class="card-header">
+              <span class="badge badge-pill badge-primary float-right">{{ forloop.counter0 }}</span>
               <p class="mb-0"><a href="{% url 'vast_pipeline:image_detail' measurement.image_id %}"
                   target="_blank">{{ measurement.image_name }}</a></p>
               <p class="mb-0"><a href="{% url 'vast_pipeline:measurement_detail' measurement.id %}"

--- a/vast_pipeline/plots.py
+++ b/vast_pipeline/plots.py
@@ -231,7 +231,10 @@ def plot_lightcurve(
             lightcurve_data.selected.indices = lightcurve_indices;
         """
         hover_tool_edges = HoverTool(
-            tooltips=None,
+            tooltips=[
+                (f"Vs {metric_suffix}", f"@vs_{metric_suffix}"),
+                (f"m {metric_suffix}", f"@m_{metric_suffix}"),
+            ],
             renderers=[edge_renderer],
             callback=CustomJS(
                 args={


### PR DESCRIPTION
Added a Bokeh hover tooltip to the measurement pair graph that displays the pair metrics when hovering over a connection. The flux type (peak or integrated) changes depending on the selected radio button in the lightcurve card header.

![image](https://user-images.githubusercontent.com/9478316/153948024-e8794d14-85fc-41ec-b314-9ee7661d4141.png)

Also added the measurement 0-index to the postage stamp card headers so it's easier to identify which image belongs to a given node in the pair graph.

![image](https://user-images.githubusercontent.com/9478316/153948095-b465b311-d128-44ec-8e5b-ea51243ccd53.png)

