### PR TITLE
Fix astroquery Ned import deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Fixed deprecation warning on astroquery Ned import [#644](https://github.com/askap-vast/vast-pipeline/pull/644).
 - Fixed a regression from pandas==1.4.0 that caused empty groups to be passed to an apply function in parallel association [#642](https://github.com/askap-vast/vast-pipeline/pull/642).
 - Fixed docs issue that stopped serializers and views being shown in the code reference [#627](https://github.com/askap-vast/vast-pipeline/pull/627).
 - Fixed broken links to external search results from NED by URI encoding source names [#633](https://github.com/askap-vast/vast-pipeline/pull/633).
@@ -91,6 +92,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#644](https://github.com/askap-vast/vast-pipeline/pull/644): fix: Fix astroquery Ned import deprecation.
 - [#638](https://github.com/askap-vast/vast-pipeline/pull/638): feat: Support defer loading of dataTables data.
 - [#641](https://github.com/askap-vast/vast-pipeline/pull/641): dep: Drop Python 3.7 and dependency refresh.
 - [#643](https://github.com/askap-vast/vast-pipeline/pull/643): fix: Addressed pandas DataFrame.append deprecation.

--- a/poetry.lock
+++ b/poetry.lock
@@ -2440,7 +2440,7 @@ prod = ["gevent", "gunicorn"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8.0,<3.11"
-content-hash = "8691ab445f5b3893ac00dcfabdf99143f867b643aa94cb88b607c40e29b67eea"
+content-hash = "88be0a1174ba726e535851688a33cbe2990ff5122720af1d72a54bdf690d64df"
 
 [metadata.files]
 ansicon = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = ">=3.8.0,<3.11"
 astropy = "^5.0"
-astroquery = "^0.4.0"
+astroquery = "^0.4.4"
 bokeh = "2.3.3" # must align with @bokeh/bokehjs version in package.json
 cloudpickle = "^1.5.0"
 dask = {extras = ["dataframe"], version = "^2022.1.0"}

--- a/vast_pipeline/utils/external_query.py
+++ b/vast_pipeline/utils/external_query.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 
 from astropy.coordinates import SkyCoord, Angle, Longitude, Latitude
 from astroquery.simbad import Simbad
-from astroquery.ned import Ned
+from astroquery.ipac.ned import Ned
 from django.conf import settings
 import requests
 


### PR DESCRIPTION
* `astroquery.ned.Ned` -> `astroquery.ipac.ned.Ned`

```
>>> from astroquery.ned import Ned
<stdin>:1: DeprecationWarning: the ``ned`` module has been moved to astroquery.ipac.ned, please update your imports.
```