### PR TITLE
Add run config option to disable measurement pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Added
 
+- Added run config option to skip calculating measurement pair metrics [#655](https://github.com/askap-vast/vast-pipeline/pull/655).
 - Added support for Python 3.10 [#641](https://github.com/askap-vast/vast-pipeline/pull/641).
 - Added documentation versioning [#627](https://github.com/askap-vast/vast-pipeline/pull/627).
 - Added a ZTF cone search button on the source detail page [#626](https://github.com/askap-vast/vast-pipeline/pull/626).
@@ -97,6 +98,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#655](https://github.com/askap-vast/vast-pipeline/pull/655): feat: Add run config option to disable measurement pairs.
 - [#648](https://github.com/askap-vast/vast-pipeline/pull/648): fix: make Image and Measurement creation atomic together.
 - [#653](https://github.com/askap-vast/vast-pipeline/pull/653): fix: Allow forced fitting on images with empty catalogues.
 - [#652](https://github.com/askap-vast/vast-pipeline/pull/652): dep, fix: Bump bokeh 2.4.2.

--- a/docs/adminusage/cli.md
+++ b/docs/adminusage/cli.md
@@ -87,7 +87,7 @@ Example usage:
 
 This command allows for the creation of the `measurements.arrow` and `measurement_pairs.arrow` files after a run has been successfully completed. See [Arrow Files](../outputs/outputs.md#arrow-files) for more information.
 
-!!!tip
+!!!info
     The `measurement_pairs.arrow` file will only be created if the run was configured to calculate pair metrics.
 
 ```terminal

--- a/docs/adminusage/cli.md
+++ b/docs/adminusage/cli.md
@@ -87,6 +87,9 @@ Example usage:
 
 This command allows for the creation of the `measurements.arrow` and `measurement_pairs.arrow` files after a run has been successfully completed. See [Arrow Files](../outputs/outputs.md#arrow-files) for more information.
 
+!!!tip
+    The `measurement_pairs.arrow` file will only be created if the run was configured to calculate pair metrics.
+
 ```terminal
 ./manage.py createmeasarrow --help
 usage: manage.py createmeasarrow [-h] [--overwrite] [--version] [-v {0,1,2,3}]

--- a/docs/design/sourcestats.md
+++ b/docs/design/sourcestats.md
@@ -70,8 +70,10 @@ where $w$ is the uncertainty ($e$) in $I$ of a measurement, and is given by $w=\
 
 ### Two-Epoch Metrics
 
-Alternative variability metrics, $V_s$ and $m$, are also calculated which we refer to as the 'two-epoch metrics'.
-They are calculated for each unique pair of measurements assoicated with the source, with the most significant pair of values attached to the source (see section below). Please refer to [Mooley et al. (2016)](https://ui.adsabs.harvard.edu/abs/2016ApJ...818..105M/abstract){:target="_blank"} for further details.
+By default, alternative variability metrics, $V_s$ and $m$, are also calculated which we refer to as the 'two-epoch metrics'.
+They are calculated for each unique pair of measurements associated with the source, with the most significant pair of values attached to the source (see section below). Please refer to [Mooley et al. (2016)](https://ui.adsabs.harvard.edu/abs/2016ApJ...818..105M/abstract){:target="_blank"} for further details.
+
+The number of measurement pairs scales exponentially with the number of measurements per source (i.e. the number of images). Runs that contain a large number of input images per source may run out memory while calculating the two-epoch metrics. If this occurs, it is recommended that the pair metric calculation is turned off in the run configuration by setting `variability.pair_metrics: False` (see [variability run configuration options](../using/runconfig.md#variability)).
 
 !!! note
     All the two-epoch pair $V_s$ and $m$ values for a run are saved in the output file `measurement_pairs.parquet` for offline analysis.
@@ -104,8 +106,8 @@ which equates to a variability of 30%. However the user is free to set their own
 
 #### Significant Source Values
 
-The $V_s$ and $m$ metrics of the 'maximum signficant pair' is attached to the source.
-The maximum significant pair is determind by selecting the most significant $\mid m \mid$ value given a minimum $V_s$ threshold which is defined in the pipeline configuration file `variability.source_aggregate_pair_metrics_min_abs_vs`:
+The $V_s$ and $m$ metrics of the 'maximum significant pair' is attached to the source.
+The maximum significant pair is determined by selecting the most significant $\mid m \mid$ value given a minimum $V_s$ threshold which is defined in the pipeline configuration file `variability.source_aggregate_pair_metrics_min_abs_vs`:
 
 !!! example "config.yaml"
     ```yaml
@@ -115,7 +117,7 @@ The maximum significant pair is determind by selecting the most significant $\mi
       source_aggregate_pair_metrics_min_abs_vs: 4.3
     ```
 
-By default this value is set to 4.3. For example, if a source with three associatied measurements gave the following pair metrics:
+By default this value is set to 4.3. For example, if a source with three associated measurements gave the following pair metrics:
 
 | Pair | $\mid V_s \mid$ | $\mid m \mid$ |
 | ---- | --------------- | ------------- |

--- a/docs/design/sourcestats.md
+++ b/docs/design/sourcestats.md
@@ -73,7 +73,8 @@ where $w$ is the uncertainty ($e$) in $I$ of a measurement, and is given by $w=\
 By default, alternative variability metrics, $V_s$ and $m$, are also calculated which we refer to as the 'two-epoch metrics'.
 They are calculated for each unique pair of measurements associated with the source, with the most significant pair of values attached to the source (see section below). Please refer to [Mooley et al. (2016)](https://ui.adsabs.harvard.edu/abs/2016ApJ...818..105M/abstract){:target="_blank"} for further details.
 
-The number of measurement pairs scales exponentially with the number of measurements per source (i.e. the number of images). Runs that contain a large number of input images per source may run out memory while calculating the two-epoch metrics. If this occurs, it is recommended that the pair metric calculation is turned off in the run configuration by setting `variability.pair_metrics: False` (see [variability run configuration options](../using/runconfig.md#variability)).
+!!!warning
+    The number of measurement pairs scales exponentially with the number of measurements per source (i.e. the number of images). Runs that contain a large number of input images per source may run out memory while calculating the two-epoch metrics. If this occurs, it is recommended that the pair metric calculation is turned off in the run configuration by setting `variability.pair_metrics: False` (see [variability run configuration options](../using/runconfig.md#variability)).
 
 !!! note
     All the two-epoch pair $V_s$ and $m$ values for a run are saved in the output file `measurement_pairs.parquet` for offline analysis.

--- a/docs/using/runconfig.md
+++ b/docs/using/runconfig.md
@@ -119,6 +119,10 @@ Below is an example of a default `config.yaml` file. Note that no images or othe
       dec_uncertainty: 1.0  # arcsec
 
     variability:
+      # For each source, calculate the measurement pair metrics (Vs and m) for each unique
+      # combination of measurements.
+      pair_metrics: True
+
       # Only measurement pairs where the Vs metric exceeds this value are selected for the
       # aggregate pair metrics that are stored in Source objects.
       source_aggregate_pair_metrics_min_abs_vs: 4.3
@@ -473,7 +477,7 @@ Float. Value to substitute for the `local_rms` parameter in selavy extractions i
 Boolean. When `True` then two `arrow` format files are produced:
 
 * `measurements.arrow` - an arrow file containing all the measurements associated with the run.
-* `measurement_pairs.arrow` -  an arrow file containing the measurement pairs information pre-merged with extra information from the measurements.
+* `measurement_pairs.arrow` -  an arrow file containing the measurement pairs information pre-merged with extra information from the measurements. Only output if `variability.pair_metrics` is also set to `True`.
 
 Producing these files for large runs (200+ images) is recommended for post-processing. Defaults to `False`.
 
@@ -488,6 +492,9 @@ Float. Defines an uncertainty error to the RA that will be added in quadrature t
 Float. Defines an uncertainty error to the Dec that will be added in quadrature to the existing source extraction error. Used to represent systematic positional error. Unit is arcseconds. Defaults to 1.0.
 
 ### Variability
+
+**`variability.pair_metrics`**
+Boolean. When `True` then the two-epoch metrics are calculated for each source. It is recommended that users set this to `False` to skip calculating the pair metrics for runs that contain many input images per source. Defaults to `True`.
 
 **`variability.source_aggregate_pair_metrics_min_abs_vs`**
 Float. Defines the minimum $V_s$ two-epoch metric value threshold used to attach the most significant pair value to the source. Defaults to `4.3`.

--- a/templates/generic_table.html
+++ b/templates/generic_table.html
@@ -273,6 +273,15 @@
             <div class="row align-items-center" style="margin-top: 1rem;">
               <div class="col">
                 <div class="custom-control custom-switch">
+                  <input type="checkbox" class="custom-control-input" id="pairMetricsSwitch" {% if runconfig.pair_metrics %} checked="checked" {% endif %} name="pair_metrics">
+                  <label class="custom-control-label font-weight-bold text-gray-800" for="pairMetricsSwitch">Calculate Pair Metrics</label>
+                  <a href="#" data-html="true" data-toggle="tooltip" data-placement="top" title=
+                      "Calculate the 2-epoch metrics for each unique of pair of measurements for each source. It is recommended that this is turned off for runs where sources will have many measurements."
+                  ><i class="fas fa-info-circle"></i></a>
+                </div>
+              </div>
+              <div class="col">
+                <div class="custom-control custom-switch">
                   <input type="checkbox" class="custom-control-input" id="condonErrorSwitch" {% if runconfig.use_condon_errors %} checked="checked" {% endif %} name="use_condon_errors">
                   <label class="custom-control-label font-weight-bold text-gray-800" for="condonErrorSwitch">Use Condon Errors</label>
                   <a href="#" data-html="true" data-toggle="tooltip" data-placement="top" title=

--- a/vast_pipeline/config_template.yaml.j2
+++ b/vast_pipeline/config_template.yaml.j2
@@ -156,6 +156,10 @@ measurements:
   dec_uncertainty: {{ astrometric_uncertainty_dec }}  # arcsec
 
 variability:
+  # For each source, calculate the measurement pair metrics (Vs and m) for each unique
+  # combination of measurements.
+  pair_metrics: {{ pair_metrics }}
+
   # Only measurement pairs where the Vs metric exceeds this value are selected for the
   # aggregate pair metrics that are stored in Source objects.
   source_aggregate_pair_metrics_min_abs_vs: {{ source_aggregate_pair_metrics_min_abs_vs }}

--- a/vast_pipeline/forms.py
+++ b/vast_pipeline/forms.py
@@ -32,6 +32,7 @@ class PipelineRunForm(forms.Form):
     flux_perc_error = forms.FloatField()
     selavy_local_rms_zero_fill_value = forms.FloatField()
     source_aggregate_pair_metrics_min_abs_vs = forms.FloatField()
+    pair_metrics = forms.BooleanField(required=False)
     use_condon_errors = forms.BooleanField(required=False)
     create_measurements_arrow_files = forms.BooleanField(required=False)
     suppress_astropy_warnings = forms.BooleanField(required=False)

--- a/vast_pipeline/management/commands/createmeasarrow.py
+++ b/vast_pipeline/management/commands/createmeasarrow.py
@@ -89,7 +89,7 @@ class Command(BaseCommand):
             options['traceback'] = True
 
         try:
-            p_run = Run.objects.get(name=p_run_name)
+            p_run: Run = Run.objects.get(name=p_run_name)
         except Run.DoesNotExist:
             raise CommandError(f'Pipeline run {p_run_name} does not exist')
 
@@ -135,11 +135,12 @@ class Command(BaseCommand):
 
         create_measurements_arrow_file(p_run)
 
-        logger.info(
-            "Creating measurement pairs arrow file for '%s'.", p_run_name
-        )
+        if p_run.get_config()["variability"]["pair_metrics"]:
+            logger.info(
+                "Creating measurement pairs arrow file for '%s'.", p_run_name
+            )
 
-        create_measurement_pairs_arrow_file(p_run)
+            create_measurement_pairs_arrow_file(p_run)
 
         logger.info(
             "Arrow files created successfully for '%s'!", p_run_name

--- a/vast_pipeline/management/commands/createmeasarrow.py
+++ b/vast_pipeline/management/commands/createmeasarrow.py
@@ -135,7 +135,7 @@ class Command(BaseCommand):
 
         create_measurements_arrow_file(p_run)
 
-        if p_run.get_config()["variability"]["pair_metrics"]:
+        if p_run.get_config(validate_inputs=False, prev=True)["variability"]["pair_metrics"]:
             logger.info(
                 "Creating measurement pairs arrow file for '%s'.", p_run_name
             )

--- a/vast_pipeline/management/commands/restorepiperun.py
+++ b/vast_pipeline/management/commands/restorepiperun.py
@@ -401,7 +401,10 @@ class Command(BaseCommand):
 
                 if os.path.isfile(f_name):
                     bak_files[i] = f_name
-                else:
+                elif (
+                    i != "measurement_pairs"
+                    or pipeline.config["variability"]["pair_metrics"]
+                ):
                     raise CommandError(
                         f'File {f_name} does not exist.'
                         ' Cannot restore pipeline run.'

--- a/vast_pipeline/management/commands/runpipeline.py
+++ b/vast_pipeline/management/commands/runpipeline.py
@@ -341,7 +341,8 @@ def run_pipe(
         # Create arrow file after success if selected.
         if pipeline.config["measurements"]["write_arrow_files"]:
             create_measurements_arrow_file(p_run)
-            create_measurement_pairs_arrow_file(p_run)
+            if pipeline.config["variability"]["pair_metrics"]:
+                create_measurement_pairs_arrow_file(p_run)
     except Exception as e:
         # set the pipeline status as error
         pipeline.set_status(p_run, 'ERR')

--- a/vast_pipeline/models.py
+++ b/vast_pipeline/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from itertools import combinations
+from pathlib import Path
 from typing import List
 
 from django.db import models
@@ -10,6 +11,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.templatetags.static import static
 from social_django.models import UserSocialAuth
 from tagulous.models import TagField
+from vast_pipeline.pipeline.config import PipelineConfig
 
 from vast_pipeline.pipeline.pairs import calculate_vs_metric, calculate_m_metric
 
@@ -173,6 +175,20 @@ class Run(CommentableModel):
         # enforce the full model validation on save
         self.full_clean()
         super(Run, self).save(*args, **kwargs)
+
+    def get_config(self, validate: bool = False) -> PipelineConfig:
+        """Read, parse, and optionally validate the run configuration file.
+
+        Args:
+            validate (bool, optional): Validate the run configuration. Defaults to False.
+
+        Returns:
+            PipelineConfig: The run configuration object.
+        """
+        config = PipelineConfig.from_file(
+            str(Path(self.path) / "config.yaml"), validate=validate
+        )
+        return config
 
 
 class Band(models.Model):

--- a/vast_pipeline/pipeline/config.py
+++ b/vast_pipeline/pipeline/config.py
@@ -126,6 +126,9 @@ class PipelineConfig:
 
         Args:
             config_yaml (yaml.YAML): Input YAML, usually the output of `strictyaml.load`.
+            validate_inputs (bool, optional): Validate the config input files. Ensures
+                that the inputs match (e.g. each image has a catalogue), and that each
+                path exists. Set to False to skip these checks. Defaults to True.
 
         Raises:
             PipelineConfigError: The input YAML config violates the schema.
@@ -247,6 +250,9 @@ class PipelineConfig:
                 will not be performed until PipelineConfig.validate() is
                 explicitly called. The inputs are always validated regardless.
                 Defaults to True.
+            validate_inputs: Validate the config input files. Ensures that the inputs
+                match (e.g. each image has a catalogue), and that each path exists. Set
+                to False to skip these checks. Defaults to True.
             add_defaults: Add missing configuration parameters using configured
                 defaults. The defaults are read from the Django settings file.
                 Defaults to True.

--- a/vast_pipeline/pipeline/config.py
+++ b/vast_pipeline/pipeline/config.py
@@ -121,7 +121,7 @@ class PipelineConfig:
         settings.BASE_DIR, "vast_pipeline", "config_template.yaml.j2"
     )
 
-    def __init__(self, config_yaml: yaml.YAML):
+    def __init__(self, config_yaml: yaml.YAML, validate_inputs: bool = True):
         """Initialises PipelineConfig with parsed (but not necessarily validated) YAML.
 
         Args:
@@ -144,6 +144,9 @@ class PipelineConfig:
         # the epochs.
 
         # ensure the inputs are valid in case .from_file(..., validate=False) was used
+        if not validate_inputs:
+            return
+
         try:
             self._validate_inputs()
         except yaml.YAMLValidationError as e:
@@ -230,6 +233,7 @@ class PipelineConfig:
         yaml_path: str,
         label: str = "run config",
         validate: bool = True,
+        validate_inputs: bool = True,
         add_defaults: bool = True,
     ) -> "PipelineConfig":
         """Create a PipelineConfig object from a run configuration YAML file.
@@ -270,7 +274,7 @@ class PipelineConfig:
             # merge configs
             config_dict = dict_merge(config_defaults_dict, config_yaml.data)
             config_yaml = yaml.as_document(config_dict, schema=schema, label=label)
-        return cls(config_yaml)
+        return cls(config_yaml, validate_inputs=validate_inputs)
 
     @staticmethod
     def _resolve_glob_expressions(input_files: yaml.YAML) -> List[str]:

--- a/vast_pipeline/pipeline/config.py
+++ b/vast_pipeline/pipeline/config.py
@@ -110,6 +110,7 @@ class PipelineConfig:
             ),
             "variability": yaml.Map(
                 {
+                    "pair_metrics": yaml.Bool(),
                     "source_aggregate_pair_metrics_min_abs_vs": yaml.Float(),
                 }
             ),

--- a/vast_pipeline/pipeline/finalise.py
+++ b/vast_pipeline/pipeline/finalise.py
@@ -187,6 +187,10 @@ def final_operations(
             "m_abs_significant_max_int": 0.0,
         })
         logger.info("Measurement pair aggregate metrics time: %.2f seconds", timer.reset())
+    else:
+        logger.info(
+            "Skipping measurement pair metric calculation as specified in the run configuration."
+        )
 
     # upload sources to DB, column 'id' with DB id is contained in return
     if add_mode:

--- a/vast_pipeline/pipeline/main.py
+++ b/vast_pipeline/pipeline/main.py
@@ -294,6 +294,7 @@ class Pipeline():
             sources_df,
             p_run,
             new_sources_df,
+            self.config["variability"]["pair_metrics"],
             self.config["variability"]["source_aggregate_pair_metrics_min_abs_vs"],
             self.add_mode,
             done_source_ids,

--- a/vast_pipeline/tests/pipeline-runs/basic-association-no-pairs/config.yaml
+++ b/vast_pipeline/tests/pipeline-runs/basic-association-no-pairs/config.yaml
@@ -1,0 +1,41 @@
+run:
+  path: vast_pipeline/tests/pipeline-runs/basic-association-no-pairs
+  suppress_astropy_warnings: true
+inputs:
+  image:
+  - vast_pipeline/tests/data/epoch01.fits
+  - vast_pipeline/tests/data/epoch02.fits
+  - vast_pipeline/tests/data/epoch03.fits
+  - vast_pipeline/tests/data/epoch04.fits
+  selavy:
+  - vast_pipeline/tests/data/epoch01.selavy.components.txt
+  - vast_pipeline/tests/data/epoch02.selavy.components.txt
+  - vast_pipeline/tests/data/epoch03.selavy.components.txt
+  - vast_pipeline/tests/data/epoch04.selavy.components.txt
+  noise:
+  - vast_pipeline/tests/data/epoch01.noiseMap.fits
+  - vast_pipeline/tests/data/epoch02.noiseMap.fits
+  - vast_pipeline/tests/data/epoch03.noiseMap.fits
+  - vast_pipeline/tests/data/epoch04.noiseMap.fits
+  background:
+  - vast_pipeline/tests/data/epoch01.meanMap.fits
+  - vast_pipeline/tests/data/epoch02.meanMap.fits
+  - vast_pipeline/tests/data/epoch03.meanMap.fits
+  - vast_pipeline/tests/data/epoch04.meanMap.fits
+source_monitoring:
+  monitor: false
+source_association:
+  method: basic
+  radius: 10.0
+new_sources:
+  min_sigma: 5.0
+measurements:
+  source_finder: selavy
+  flux_fractional_error: 0.0
+  condon_errors: true
+  selavy_local_rms_fill_value: 0.2
+  ra_uncertainty: 1
+  dec_uncertainty: 1
+variability:
+  pair_metrics: false
+  source_aggregate_pair_metrics_min_abs_vs: 4.3

--- a/vast_pipeline/tests/test_runpipeline.py
+++ b/vast_pipeline/tests/test_runpipeline.py
@@ -1,5 +1,6 @@
 import glob
 import os
+from typing import List, Optional
 
 from django.conf import settings as s
 from django.test import TestCase, override_settings
@@ -11,46 +12,43 @@ from vast_pipeline.models import Image
 TEST_ROOT = os.path.join(s.BASE_DIR, 'vast_pipeline', 'tests')
 
 
+def _cleanup_test_run(run_dir: str, run_logs: Optional[List[str]] = None):
+    call_command('clearpiperun', run_dir)
+    prev_config_path = os.path.join(run_dir, "config_prev.yaml")
+    if os.path.exists(prev_config_path):
+        os.remove(prev_config_path)
+    if run_logs is None:
+        run_logs = glob.glob(os.path.join(run_dir, '*_log.txt'))
+    for run_log in run_logs:
+        os.remove(run_log)
+
+
 @override_settings(
     PIPELINE_WORKING_DIR=os.path.join(TEST_ROOT, 'pipeline-runs'),
     RAW_IMAGE_DIR=os.path.join(TEST_ROOT, 'data'),
 )
 class RunPipelineTest(TestCase):
     run_dir: str
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.run_dir = os.path.join(s.PIPELINE_WORKING_DIR, 'basic-association')
-
-    def setUp(self):
-        # TODO: replace with a load images function and call 'runpipeline'
-        # from each tests (e.g. test_basic_assoc, text_advanced_assoc, etc.)
-        call_command('runpipeline', self.run_dir)
-        self.run_logs = glob.glob(os.path.join(self.run_dir, '*_log.txt'))
+    run_logs: Optional[List[str]] = None
 
     def tearDown(self):
         """Clean up the run directory after the test by removing the backup config and
         all run logs.
         """
-        call_command('clearpiperun', self.run_dir)
-        os.remove(os.path.join(self.run_dir, "config_prev.yaml"))
-        for run_log in self.run_logs:
-            os.remove(run_log)
+        _cleanup_test_run(self.run_dir, run_logs=self.run_logs)
 
     def test_check_run(self):
+        self.run_dir = os.path.join(s.PIPELINE_WORKING_DIR, 'basic-association')
+        # TODO: replace with a load images function and call 'runpipeline'
+        # from each tests (e.g. test_basic_assoc, text_advanced_assoc, etc.)
+        call_command('runpipeline', self.run_dir)
+        self.run_logs = glob.glob(os.path.join(self.run_dir, '*_log.txt'))
         self.assertEqual(len(self.run_logs), 1)
 
-
-@override_settings(
-    PIPELINE_WORKING_DIR=os.path.join(TEST_ROOT, 'pipeline-runs'),
-    RAW_IMAGE_DIR=os.path.join(TEST_ROOT, 'data'),
-)
-class RunPipelineInvalidCatalogTest(TestCase):
     def test_invalid_catalog(self):
-        run_dir = os.path.join(s.PIPELINE_WORKING_DIR, 'basic-association-invalid-catalog')
+        self.run_dir = os.path.join(s.PIPELINE_WORKING_DIR, 'basic-association-invalid-catalog')
         with self.assertRaises(CommandError) as context:
-            call_command('runpipeline', run_dir)
+            call_command('runpipeline', self.run_dir)
         # check the original exception raised during runpipeline command is a KeyError
         # (caused by attempting to read the invalid catalog)
         original_exception = context.exception.__context__
@@ -61,3 +59,19 @@ class RunPipelineInvalidCatalogTest(TestCase):
             self.assertIsInstance(image, Image)
         with self.assertRaises(Image.DoesNotExist):
             Image.objects.get(name="epoch05.fits")
+        # clean up config backup
+        os.remove(os.path.join(self.run_dir, "config_temp.yaml"))
+
+    def test_pair_metrics_exist(self):
+        self.run_dir = os.path.join(s.PIPELINE_WORKING_DIR, 'basic-association')
+        call_command('runpipeline', self.run_dir)
+        # check that the measurement pairs parquet file was written
+        self.assertTrue(os.path.exists(os.path.join(self.run_dir, "measurement_pairs.parquet")))
+
+    def test_no_pair_metrics(self):
+        self.run_dir = os.path.join(s.PIPELINE_WORKING_DIR, 'basic-association-no-pairs')
+        call_command('runpipeline', self.run_dir)
+        # check that the measurement pairs parquet file was not written
+        self.assertFalse(os.path.exists(os.path.join(self.run_dir, "measurement_pairs.parquet")))
+        # check that at least one of the other parquets were written
+        self.assertTrue(os.path.exists(os.path.join(self.run_dir, "sources.parquet")))

--- a/webinterface/settings.py
+++ b/webinterface/settings.py
@@ -334,6 +334,7 @@ PIPE_RUN_CONFIG_DEFAULTS = {
     'selavy_local_rms_zero_fill_value': 0.2,
     'create_measurements_arrow_files': False,
     'suppress_astropy_warnings': True,
+    'pair_metrics': True,
     'source_aggregate_pair_metrics_min_abs_vs': 4.3,
 }
 


### PR DESCRIPTION
Adds a run configuration option to skip the calculation of measurement pairs which can be resource-intensive for certain runs. See #654.

The new option is `variability.pair_metrics` and is `True` by default to match the existing behaviour. Runs with the pair metrics disabled will not write a `measurement_pairs.parquet` file. Similarly, the arrow format equivalent is not written if requested. The maximum Vs/m metrics stored in the `Source` models are all set to 0.

Measurement pairs are also calculated when rendering the plots on the source detail page. For runs where the pair metrics are turned off, this step is now skipped. Some changes were required to the `PipelineConfig` class to allow the run config to be read and parsed, but not validate the inputs. Skipping input validation in this scenario is desirable as large runs can take a long time to validate while the glob expressions are resolved. The existing validation skip was insufficient as we need the `variability.pair_metrics` value to be parsed (i.e. the value must be a bool as dictated by the schema - without validating the values are left as strings).

Will update the changelog when tests pass.

- [x] Add run config option
- [x] Update docs
- [x] Add tests
- [x] Update changelog