### PR TITLE
npm audit and js9 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Changed
 
+- Bumped js9 to 3.7 and applied npm audit to close security issues [#660](https://github.com/askap-vast/vast-pipeline/pull/660).
 - Changed lightcurve plot cursor hit-test mode from "vline" to "mouse" to avoid a regression in Bokeh [#652](https://github.com/askap-vast/vast-pipeline/pull/652).
 - Updated Bokeh from v2.3.3 to v2.4.2 [#652](https://github.com/askap-vast/vast-pipeline/pull/652).
 - Source query results table is no longer populated by default, a query must be submitted first [#638](https://github.com/askap-vast/vast-pipeline/pull/638).
@@ -99,6 +100,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#660](https://github.com/askap-vast/vast-pipeline/pull/660): feat: npm audit and js9 bump.
 - [#658](https://github.com/askap-vast/vast-pipeline/pull/658): feat: Add MAX_CUTOUT_IMAGES setting.
 - [#655](https://github.com/askap-vast/vast-pipeline/pull/655): feat: Add run config option to disable measurement pairs.
 - [#648](https://github.com/askap-vast/vast-pipeline/pull/648): fix: make Image and Measurement creation atomic together.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0dev",
       "license": "MIT",
       "dependencies": {
-        "@bokeh/bokehjs": "^2.4.2",
+        "@bokeh/bokehjs": "2.4.2",
         "@fortawesome/fontawesome-free": "5.12.0",
         "bootstrap-select": "^1.13.18",
         "bootstrap4-toggle": "3.6.1",
@@ -2286,10 +2286,13 @@
       }
     },
     "node_modules/async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
     },
     "node_modules/async-done": {
       "version": "1.3.2",
@@ -2315,7 +2318,7 @@
     "node_modules/async-each-series": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
-      "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
+      "integrity": "sha512-p4jj6Fws4Iy2m0iCmI2am2ZNZCgbdgE+P8F/8csmn2vx7ixXrO2zGcuNsD46X5uZSVecmkEy/M06X2vG8KD6dQ==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -2594,13 +2597,13 @@
       }
     },
     "node_modules/browser-sync": {
-      "version": "2.27.9",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.9.tgz",
-      "integrity": "sha512-3zBtggcaZIeU9so4ja9yxk7/CZu9B3DOL6zkxFpzHCHsQmkGBPVXg61jItbeoa+WXgNLnr1sYES/2yQwyEZ2+w==",
+      "version": "2.27.10",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.10.tgz",
+      "integrity": "sha512-xKm+6KJmJu6RuMWWbFkKwOCSqQOxYe3nOrFkKI5Tr/ZzjPxyU3pFShKK3tWnazBo/3lYQzN7fzjixG8fwJh1Xw==",
       "dev": true,
       "dependencies": {
-        "browser-sync-client": "^2.27.9",
-        "browser-sync-ui": "^2.27.9",
+        "browser-sync-client": "^2.27.10",
+        "browser-sync-ui": "^2.27.10",
         "bs-recipes": "1.3.4",
         "bs-snippet-injector": "^2.0.1",
         "chokidar": "^3.5.1",
@@ -2617,7 +2620,7 @@
         "localtunnel": "^2.0.1",
         "micromatch": "^4.0.2",
         "opn": "5.3.0",
-        "portscanner": "2.1.1",
+        "portscanner": "2.2.0",
         "qs": "6.2.3",
         "raw-body": "^2.3.2",
         "resp-modifier": "6.0.2",
@@ -2638,24 +2641,25 @@
       }
     },
     "node_modules/browser-sync-client": {
-      "version": "2.27.9",
-      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.9.tgz",
-      "integrity": "sha512-FHW8kydp7FXo6jnX3gXJCpHAHtWNLK0nx839nnK+boMfMI1n4KZd0+DmTxHBsHsF3OHud4V4jwoN8U5HExMIdQ==",
+      "version": "2.27.10",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.10.tgz",
+      "integrity": "sha512-KCFKA1YDj6cNul0VsA28apohtBsdk5Wv8T82ClOZPZMZWxPj4Ny5AUbrj9UlAb/k6pdxE5HABrWDhP9+cjt4HQ==",
       "dev": true,
       "dependencies": {
         "etag": "1.8.1",
         "fresh": "0.5.2",
         "mitt": "^1.1.3",
-        "rxjs": "^5.5.6"
+        "rxjs": "^5.5.6",
+        "typescript": "^4.6.2"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/browser-sync-ui": {
-      "version": "2.27.9",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.9.tgz",
-      "integrity": "sha512-rsduR2bRIwFvM8CX6iY/Nu5aWub0WB9zfSYg9Le/RV5N5DEyxJYey0VxdfWCnzDOoelassTDzYQo+r0iJno3qw==",
+      "version": "2.27.10",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.10.tgz",
+      "integrity": "sha512-elbJILq4Uo6OQv6gsvS3Y9vRAJlWu+h8j0JDkF0X/ua+3S6SVbbiWnZc8sNOFlG7yvVGIwBED3eaYQ0iBo1Dtw==",
       "dev": true,
       "dependencies": {
         "async-each-series": "0.1.1",
@@ -5950,9 +5954,9 @@
       "dev": true
     },
     "node_modules/js9": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/js9/-/js9-3.6.2.tgz",
-      "integrity": "sha512-pWFicm3reTF6hQmzaGprnkZrHxmKqry5+DMZhJnwE39NYmn0AqHsDij6HPn2lOG4agwuiQptY0UyAPHBIoboDw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/js9/-/js9-3.7.0.tgz",
+      "integrity": "sha512-wxrDFZA15cF39FCkDujKhkSGWPs5+zFb+CZDKy0t3SC/F2inpwpF6YbbNnkWNaoGY+toZpjnDsyEFX6l7fEj6w==",
       "bundleDependencies": [
         "minimist",
         "open",
@@ -5967,8 +5971,16 @@
         "ps-list": "*",
         "rimraf": "*",
         "socket.io": "*",
-        "socket.io-client": "^4.3.2",
+        "socket.io-client": "^4.4.1",
         "uuid": "*"
+      }
+    },
+    "node_modules/js9/node_modules/@socket.io/base64-arraybuffer": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/js9/node_modules/@types/component-emitter": {
@@ -5987,17 +5999,17 @@
       "license": "MIT"
     },
     "node_modules/js9/node_modules/@types/node": {
-      "version": "16.11.10",
+      "version": "17.0.27",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/js9/node_modules/accepts": {
-      "version": "1.3.7",
+      "version": "1.3.8",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       },
       "engines": {
         "node": ">= 0.6"
@@ -6007,14 +6019,6 @@
       "version": "1.0.0",
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/js9/node_modules/base64-arraybuffer": {
-      "version": "1.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
     },
     "node_modules/js9/node_modules/base64id": {
       "version": "2.0.0",
@@ -6044,7 +6048,7 @@
       "license": "MIT"
     },
     "node_modules/js9/node_modules/cookie": {
-      "version": "0.4.1",
+      "version": "0.4.2",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6088,7 +6092,7 @@
       }
     },
     "node_modules/js9/node_modules/engine.io": {
-      "version": "6.1.0",
+      "version": "6.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6100,7 +6104,7 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.0",
+        "engine.io-parser": "~5.0.3",
         "ws": "~8.2.3"
       },
       "engines": {
@@ -6108,11 +6112,11 @@
       }
     },
     "node_modules/js9/node_modules/engine.io-parser": {
-      "version": "5.0.1",
+      "version": "5.0.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "base64-arraybuffer": "~1.0.1"
+        "@socket.io/base64-arraybuffer": "~1.0.2"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -6182,7 +6186,7 @@
       }
     },
     "node_modules/js9/node_modules/mime-db": {
-      "version": "1.51.0",
+      "version": "1.52.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6190,11 +6194,11 @@
       }
     },
     "node_modules/js9/node_modules/mime-types": {
-      "version": "2.1.34",
+      "version": "2.1.35",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.51.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -6212,7 +6216,7 @@
       }
     },
     "node_modules/js9/node_modules/minimist": {
-      "version": "1.2.5",
+      "version": "1.2.6",
       "inBundle": true,
       "license": "MIT"
     },
@@ -6222,7 +6226,7 @@
       "license": "MIT"
     },
     "node_modules/js9/node_modules/negotiator": {
-      "version": "0.6.2",
+      "version": "0.6.3",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6295,15 +6299,15 @@
       }
     },
     "node_modules/js9/node_modules/socket.io": {
-      "version": "4.4.0",
+      "version": "4.5.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.2",
-        "engine.io": "~6.1.0",
-        "socket.io-adapter": "~2.3.3",
+        "engine.io": "~6.2.0",
+        "socket.io-adapter": "~2.4.0",
         "socket.io-parser": "~4.0.4"
       },
       "engines": {
@@ -6311,7 +6315,7 @@
       }
     },
     "node_modules/js9/node_modules/socket.io-adapter": {
-      "version": "2.3.3",
+      "version": "2.4.0",
       "inBundle": true,
       "license": "MIT"
     },
@@ -7641,12 +7645,12 @@
       }
     },
     "node_modules/portscanner": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
-      "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
+      "integrity": "sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==",
       "dev": true,
       "dependencies": {
-        "async": "1.5.2",
+        "async": "^2.6.0",
         "is-number-like": "^1.0.3"
       },
       "engines": {
@@ -9468,6 +9472,19 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
     "node_modules/ua-parser-js": {
       "version": "1.0.2",
@@ -11679,10 +11696,13 @@
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "async-done": {
       "version": "1.3.2",
@@ -11705,7 +11725,7 @@
     "async-each-series": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
-      "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
+      "integrity": "sha512-p4jj6Fws4Iy2m0iCmI2am2ZNZCgbdgE+P8F/8csmn2vx7ixXrO2zGcuNsD46X5uZSVecmkEy/M06X2vG8KD6dQ==",
       "dev": true
     },
     "async-settle": {
@@ -11933,13 +11953,13 @@
       }
     },
     "browser-sync": {
-      "version": "2.27.9",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.9.tgz",
-      "integrity": "sha512-3zBtggcaZIeU9so4ja9yxk7/CZu9B3DOL6zkxFpzHCHsQmkGBPVXg61jItbeoa+WXgNLnr1sYES/2yQwyEZ2+w==",
+      "version": "2.27.10",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.10.tgz",
+      "integrity": "sha512-xKm+6KJmJu6RuMWWbFkKwOCSqQOxYe3nOrFkKI5Tr/ZzjPxyU3pFShKK3tWnazBo/3lYQzN7fzjixG8fwJh1Xw==",
       "dev": true,
       "requires": {
-        "browser-sync-client": "^2.27.9",
-        "browser-sync-ui": "^2.27.9",
+        "browser-sync-client": "^2.27.10",
+        "browser-sync-ui": "^2.27.10",
         "bs-recipes": "1.3.4",
         "bs-snippet-injector": "^2.0.1",
         "chokidar": "^3.5.1",
@@ -11956,7 +11976,7 @@
         "localtunnel": "^2.0.1",
         "micromatch": "^4.0.2",
         "opn": "5.3.0",
-        "portscanner": "2.1.1",
+        "portscanner": "2.2.0",
         "qs": "6.2.3",
         "raw-body": "^2.3.2",
         "resp-modifier": "6.0.2",
@@ -11971,21 +11991,22 @@
       }
     },
     "browser-sync-client": {
-      "version": "2.27.9",
-      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.9.tgz",
-      "integrity": "sha512-FHW8kydp7FXo6jnX3gXJCpHAHtWNLK0nx839nnK+boMfMI1n4KZd0+DmTxHBsHsF3OHud4V4jwoN8U5HExMIdQ==",
+      "version": "2.27.10",
+      "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.10.tgz",
+      "integrity": "sha512-KCFKA1YDj6cNul0VsA28apohtBsdk5Wv8T82ClOZPZMZWxPj4Ny5AUbrj9UlAb/k6pdxE5HABrWDhP9+cjt4HQ==",
       "dev": true,
       "requires": {
         "etag": "1.8.1",
         "fresh": "0.5.2",
         "mitt": "^1.1.3",
-        "rxjs": "^5.5.6"
+        "rxjs": "^5.5.6",
+        "typescript": "^4.6.2"
       }
     },
     "browser-sync-ui": {
-      "version": "2.27.9",
-      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.9.tgz",
-      "integrity": "sha512-rsduR2bRIwFvM8CX6iY/Nu5aWub0WB9zfSYg9Le/RV5N5DEyxJYey0VxdfWCnzDOoelassTDzYQo+r0iJno3qw==",
+      "version": "2.27.10",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.10.tgz",
+      "integrity": "sha512-elbJILq4Uo6OQv6gsvS3Y9vRAJlWu+h8j0JDkF0X/ua+3S6SVbbiWnZc8sNOFlG7yvVGIwBED3eaYQ0iBo1Dtw==",
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
@@ -14693,19 +14714,23 @@
       "dev": true
     },
     "js9": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/js9/-/js9-3.6.2.tgz",
-      "integrity": "sha512-pWFicm3reTF6hQmzaGprnkZrHxmKqry5+DMZhJnwE39NYmn0AqHsDij6HPn2lOG4agwuiQptY0UyAPHBIoboDw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/js9/-/js9-3.7.0.tgz",
+      "integrity": "sha512-wxrDFZA15cF39FCkDujKhkSGWPs5+zFb+CZDKy0t3SC/F2inpwpF6YbbNnkWNaoGY+toZpjnDsyEFX6l7fEj6w==",
       "requires": {
         "minimist": "*",
         "open": "*",
         "ps-list": "*",
         "rimraf": "*",
         "socket.io": "*",
-        "socket.io-client": "^4.3.2",
+        "socket.io-client": "^4.4.1",
         "uuid": "*"
       },
       "dependencies": {
+        "@socket.io/base64-arraybuffer": {
+          "version": "1.0.2",
+          "bundled": true
+        },
         "@types/component-emitter": {
           "version": "1.2.10",
           "bundled": true
@@ -14719,23 +14744,19 @@
           "bundled": true
         },
         "@types/node": {
-          "version": "16.11.10",
+          "version": "17.0.27",
           "bundled": true
         },
         "accepts": {
-          "version": "1.3.7",
+          "version": "1.3.8",
           "bundled": true,
           "requires": {
-            "mime-types": "~2.1.24",
-            "negotiator": "0.6.2"
+            "mime-types": "~2.1.34",
+            "negotiator": "0.6.3"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
-        },
-        "base64-arraybuffer": {
-          "version": "1.0.1",
           "bundled": true
         },
         "base64id": {
@@ -14759,7 +14780,7 @@
           "bundled": true
         },
         "cookie": {
-          "version": "0.4.1",
+          "version": "0.4.2",
           "bundled": true
         },
         "cors": {
@@ -14782,7 +14803,7 @@
           "bundled": true
         },
         "engine.io": {
-          "version": "6.1.0",
+          "version": "6.2.0",
           "bundled": true,
           "requires": {
             "@types/cookie": "^0.4.1",
@@ -14793,15 +14814,15 @@
             "cookie": "~0.4.1",
             "cors": "~2.8.5",
             "debug": "~4.3.1",
-            "engine.io-parser": "~5.0.0",
+            "engine.io-parser": "~5.0.3",
             "ws": "~8.2.3"
           }
         },
         "engine.io-parser": {
-          "version": "5.0.1",
+          "version": "5.0.3",
           "bundled": true,
           "requires": {
-            "base64-arraybuffer": "~1.0.1"
+            "@socket.io/base64-arraybuffer": "~1.0.2"
           }
         },
         "fs.realpath": {
@@ -14844,14 +14865,14 @@
           }
         },
         "mime-db": {
-          "version": "1.51.0",
+          "version": "1.52.0",
           "bundled": true
         },
         "mime-types": {
-          "version": "2.1.34",
+          "version": "2.1.35",
           "bundled": true,
           "requires": {
-            "mime-db": "1.51.0"
+            "mime-db": "1.52.0"
           }
         },
         "minimatch": {
@@ -14862,7 +14883,7 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
+          "version": "1.2.6",
           "bundled": true
         },
         "ms": {
@@ -14870,7 +14891,7 @@
           "bundled": true
         },
         "negotiator": {
-          "version": "0.6.2",
+          "version": "0.6.3",
           "bundled": true
         },
         "object-assign": {
@@ -14909,19 +14930,19 @@
           }
         },
         "socket.io": {
-          "version": "4.4.0",
+          "version": "4.5.0",
           "bundled": true,
           "requires": {
             "accepts": "~1.3.4",
             "base64id": "~2.0.0",
             "debug": "~4.3.2",
-            "engine.io": "~6.1.0",
-            "socket.io-adapter": "~2.3.3",
+            "engine.io": "~6.2.0",
+            "socket.io-adapter": "~2.4.0",
             "socket.io-parser": "~4.0.4"
           }
         },
         "socket.io-adapter": {
-          "version": "2.3.3",
+          "version": "2.4.0",
           "bundled": true
         },
         "socket.io-parser": {
@@ -15972,12 +15993,12 @@
       "peer": true
     },
     "portscanner": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
-      "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
+      "integrity": "sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
+        "async": "^2.6.0",
         "is-number-like": "^1.0.3"
       }
     },
@@ -17468,6 +17489,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "dev": true
     },
     "ua-parser-js": {


### PR DESCRIPTION
- audit fix.
- js9 updated to address minimist and engine.io.

Tested web interface and all appears to be working.

Will also apply #635.