### PR TITLE
Optimise YAML config parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Optimise YAML config parsing [#754](https://github.com/askap-vast/vast-pipeline/pull/754)
 - Fixed mkdocs serving issues [#728](https://github.com/askap-vast/vast-pipeline/pull/728)
 - Fixed python 3.9 testing failing on github actions [#728](https://github.com/askap-vast/vast-pipeline/pull/728)
 - Updated github action syntax to correctly call docker compose [#736](https://github.com/askap-vast/vast-pipeline/pull/736)
@@ -127,6 +128,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#754](https://github.com/askap-vast/vast-pipeline/pull/754): fix: Optimise YAML config parsing
 - [#725](https://github.com/askap-vast/vast-pipeline/pull/725): feat: Added further memory usage and timing debug logging 
 - [#740](https://github.com/askap-vast/vast-pipeline/pull/740): feat: Add support for python 3.10
 - [#728](https://github.com/askap-vast/vast-pipeline/pull/728): fix: Adjust package versions and fix mkdocs serve issues

--- a/vast_pipeline/management/commands/runpipeline.py
+++ b/vast_pipeline/management/commands/runpipeline.py
@@ -295,25 +295,26 @@ def run_pipe(
     )
 
     # log the list of input data files for posterity
+    inputs = pipeline.config["inputs"]
     input_image_list = [
         image
-        for image_list in pipeline.config["inputs"]["image"].values()
+        for image_list in inputs["image"].values()
         for image in image_list
     ]
     input_selavy_list = [
         selavy
-        for selavy_list in pipeline.config["inputs"]["selavy"].values()
+        for selavy_list in inputs["selavy"].values()
         for selavy in selavy_list
     ]
     input_noise_list = [
         noise
-        for noise_list in pipeline.config["inputs"]["noise"].values()
+        for noise_list in inputs["noise"].values()
         for noise in noise_list
     ]
-    if "background" in pipeline.config["inputs"].keys():
+    if "background" in inputs.keys():
         input_background_list = [
             background
-            for background_list in pipeline.config["inputs"]["background"].values()
+            for background_list in inputs["background"].values()
             for background in background_list
         ]
     else:

--- a/vast_pipeline/pipeline/config.py
+++ b/vast_pipeline/pipeline/config.py
@@ -386,18 +386,15 @@ class PipelineConfig:
             for input_type in inputs.keys()
         }
         # map input type to total number of files from all epochs
-        n_files_by_input_type = {}
+        n_files_by_input_type: Dict[str, int] = {}
+        epoch_n_files: Dict[str, Dict[str, int]] = {}
+        n_files = 0
         for input_type, epochs_set in epochs_by_input_type.items():
+            epoch_n_files[input_type] = {}
             n_files_by_input_type[input_type] = 0
             for epoch in epochs_set:
-                n_files_by_input_type[input_type] += len(inputs[input_type][epoch])
-        n_files = 0  # total number of input files
-        # map input type to a mapping of epoch to file count
-        epoch_n_files: Dict[str, Dict[str, int]] = {}
-        for input_type in inputs.keys():
-            epoch_n_files[input_type] = {}
-            for epoch in inputs[input_type].keys():
                 n = len(inputs[input_type][epoch])
+                n_files_by_input_type[input_type] += n
                 epoch_n_files[input_type][epoch] = n
                 n_files += n
 

--- a/vast_pipeline/pipeline/main.py
+++ b/vast_pipeline/pipeline/main.py
@@ -92,22 +92,23 @@ class Pipeline():
         Returns:
             None
         """
-        for key in sorted(self.config["inputs"]["image"].keys()):
+        inputs = self.config["inputs"]
+        for key in sorted(inputs["image"].keys()):
             for x, y in zip(
-                self.config["inputs"]["image"][key],
-                self.config["inputs"]["selavy"][key],
+                inputs["image"][key],
+                inputs["selavy"][key],
             ):
                 self.img_paths["selavy"][x] = y
                 self.img_epochs[os.path.basename(x)] = key
             for x, y in zip(
-                self.config["inputs"]["image"][key],
-                self.config["inputs"]["noise"][key]
+                inputs["image"][key],
+                inputs["noise"][key]
             ):
                 self.img_paths["noise"][x] = y
             if "background" in self.config["inputs"]:
                 for x, y in zip(
-                    self.config["inputs"]["image"][key],
-                    self.config["inputs"]["background"][key],
+                    inputs["image"][key],
+                    inputs["background"][key],
                 ):
                     self.img_paths["background"][x] = y
 


### PR DESCRIPTION
Optimise read of YAML configuration at the start of the pipeline by copying the configuration into a dictionary before reading or updating it. This prevents `strictyaml` from validating the YAML on every read or write and only lets the validation happen on bulk reads or writes.

This closes #751 