### PR TITLE
Fix noise image statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
-- [#755](https://github.com/askap-vast/vast-pipeline/pull/755): fix: Fixed noise image statistics
+- [#755](https://github.com/askap-vast/vast-pipeline/pull/755): fix: Fixed handling of NaNs and negatives in noise image statistics
 - [#754](https://github.com/askap-vast/vast-pipeline/pull/754): fix: Optimise YAML config parsing
 - [#725](https://github.com/askap-vast/vast-pipeline/pull/725): feat: Added further memory usage and timing debug logging 
 - [#740](https://github.com/askap-vast/vast-pipeline/pull/740): feat: Add support for python 3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
-- Fixed noise image statistics [#755](https://github.com/askap-vast/vast-pipeline/pull/755)
+- Fixed handling of NaNs and negatives in noise image statistics [#755](https://github.com/askap-vast/vast-pipeline/pull/755)
 - Optimise YAML config parsing [#754](https://github.com/askap-vast/vast-pipeline/pull/754)
 - Fixed mkdocs serving issues [#728](https://github.com/askap-vast/vast-pipeline/pull/728)
 - Fixed python 3.9 testing failing on github actions [#728](https://github.com/askap-vast/vast-pipeline/pull/728)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Fixed noise image statistics [#755](https://github.com/askap-vast/vast-pipeline/pull/755)
 - Fixed mkdocs serving issues [#728](https://github.com/askap-vast/vast-pipeline/pull/728)
 - Fixed python 3.9 testing failing on github actions [#728](https://github.com/askap-vast/vast-pipeline/pull/728)
 - Updated github action syntax to correctly call docker compose [#736](https://github.com/askap-vast/vast-pipeline/pull/736)
@@ -127,6 +128,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#755](https://github.com/askap-vast/vast-pipeline/pull/755): fix: Fixed noise image statistics
 - [#725](https://github.com/askap-vast/vast-pipeline/pull/725): feat: Added further memory usage and timing debug logging 
 - [#740](https://github.com/askap-vast/vast-pipeline/pull/740): feat: Add support for python 3.10
 - [#728](https://github.com/askap-vast/vast-pipeline/pull/728): fix: Adjust package versions and fix mkdocs serve issues

--- a/vast_pipeline/pipeline/utils.py
+++ b/vast_pipeline/pipeline/utils.py
@@ -806,8 +806,7 @@ def get_rms_noise_image_values(rms_path: str) -> Tuple[float, float, float]:
     try:
         with open_fits(rms_path) as f:
             data = f[0].data
-            data = data[np.logical_not(np.isnan(data))]
-            data = data[data != 0]
+            data = data[np.isfinite(data) & (data >= 0.)]
             med_val = np.median(data) * 1e+3
             min_val = np.min(data) * 1e+3
             max_val = np.max(data) * 1e+3

--- a/vast_pipeline/pipeline/utils.py
+++ b/vast_pipeline/pipeline/utils.py
@@ -806,7 +806,7 @@ def get_rms_noise_image_values(rms_path: str) -> Tuple[float, float, float]:
     try:
         with open_fits(rms_path) as f:
             data = f[0].data
-            data = data[np.isfinite(data) & (data >= 0.)]
+            data = data[np.isfinite(data) & (data > 0.)]
             med_val = np.median(data) * 1e+3
             min_val = np.min(data) * 1e+3
             max_val = np.max(data) * 1e+3

--- a/vast_pipeline/pipeline/utils.py
+++ b/vast_pipeline/pipeline/utils.py
@@ -813,6 +813,7 @@ def get_rms_noise_image_values(rms_path: str) -> Tuple[float, float, float]:
             del data
     except Exception:
         raise IOError(f'Could not read this RMS FITS file: {rms_path}')
+    logger.debug('Image RMS Min: %.3g Max: %.3g Median: %.3g', min_val, max_val, med_val)
 
     return med_val, min_val, max_val
 


### PR DESCRIPTION
Check for negative pixes as well as 0 or NaN ones in the noise images when calculating statistics.

This fixes #753 