### PR TITLE
752 merge sky region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### Changed
 
 - Updated changelog release instructions to remove each release having an empty "Unreleased" section at the start [#772](https://github.com/askap-vast/vast-pipeline/pull/772)
+- Search in a 10 arcsec radius for an existing SkyRegion when adding new images (#759](https://github.com/askap-vast/vast-pipeline/pull/759)
 
 #### Fixed
 
@@ -23,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 #### List of PRs
 
 - [#772](https://github.com/askap-vast/vast-pipeline/pull/772): fix, docs: Fixed changelog formatting and updated changelog release instructions
+- [#759](https://github.com/askap-vast/vast-pipeline/pull/759): feat: Do a cone search for existing SkyRegions when adding new images
 
 ## [1.1.1](https://github.com/askap-vast/vast-pipeline/releases/v1.1.1) (2024-10-15)
 

--- a/vast_pipeline/pipeline/utils.py
+++ b/vast_pipeline/pipeline/utils.py
@@ -37,27 +37,38 @@ logger = logging.getLogger(__name__)
 dask.config.set({"multiprocessing.context": "fork"})
 
 
-def get_create_skyreg(image: Image) -> SkyRegion:
+def get_create_skyreg(image: Image, radius: float = 10.) -> SkyRegion:
     '''
-    This creates a Sky Region object in Django ORM given the related
-    image object.
+    This creates a SkyRegion object in Django ORM given the related
+    image object. If a SkyRegion already exists and has an image radius
+    within `radius` arcsec of the input image then use that SkyRegion.
 
     Args:
         image: The image Django ORM object.
+        radius: Search radius (in arcsec) for matching to existing SkyRegion
 
     Returns:
         The sky region Django ORM object.
     '''
-    # In the calculations below, it is assumed the image has square
+    # NOTE: In the calculations below, it is assumed the image has square
     # pixels (this pipeline has been designed for ASKAP images, so it
     # should always be square). It will likely give wrong results if not
-    skyregions = SkyRegion.objects.filter(
-        centre_ra=image.ra,
-        centre_dec=image.dec,
-        xtr_radius=image.fov_bmin
+
+    # Get SkyRegions and image radii areas within `radius` arcsec
+    radius_deg = radius/3600.
+    skyregions = SkyRegion.objects.cone_search(
+        ra=image.ra,
+        dec=image.dec,
+        radius_deg=radius_deg
+    ).filter(
+        xtr_radius__range=(
+            image.fov_bmin - radius_deg/2.,
+            image.fov_bmin + radius_deg/2.
+        )
     )
     if skyregions:
-        skyr = skyregions.get()
+        # Get the closest in case of multiple matches.
+        skyr = skyregions[0]
         logger.info('Found sky region %s', skyr)
     else:
         x, y, z = eq_to_cart(image.ra, image.dec)

--- a/vast_pipeline/pipeline/utils.py
+++ b/vast_pipeline/pipeline/utils.py
@@ -57,9 +57,9 @@ def get_create_skyreg(image: Image, radius: float = 10.) -> SkyRegion:
     # Get SkyRegions and image radii areas within `radius` arcsec
     radius_deg = radius/3600.
     skyregions = SkyRegion.objects.cone_search(
-        ra=image.ra,
-        dec=image.dec,
-        radius_deg=radius_deg
+        ra=float(image.ra),
+        dec=float(image.dec),
+        radius_deg=float(radius_deg)
     ).filter(
         xtr_radius__range=(
             image.fov_bmin - radius_deg/2.,


### PR DESCRIPTION
Fix issue 752 by including a radius around which to search for an Existing SkyRegion at the input image position.

For now the radius of 10arcsec is hard-coded as a function default - In future this can be added as a configuration parameter.

Dont merge until after v1.x releases.