### PR TITLE
Quick memory optimisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Changed
 
+- Small memory optimisations: Use `itertuples` in favour of `iterrows`, Loop over mappings rather than converting them to lists up-front. [#776](https://github.com/askap-vast/vast-pipeline/pull/776)
 - Shortened forced fits measurement names to ensure they fit within the character limits - remove image prefix and limited to 1000 forced fits per source [#734](https://github.com/askap-vast/vast-pipeline/pull/734)
 - Cleaned up Code of Conduct including adding Zenodo DOI [#773](https://github.com/askap-vast/vast-pipeline/pull/773)
 - Updated changelog release instructions to remove each release having an empty "Unreleased" section at the start [#772](https://github.com/askap-vast/vast-pipeline/pull/772)
@@ -24,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#776](https://github.com/askap-vast/vast-pipeline/pull/776): Minor memory optimisations
 - [#734](https://github.com/askap-vast/vast-pipeline/pull/734): Shortened forced fits measurement names
 - [#773](https://github.com/askap-vast/vast-pipeline/pull/773): docs: Cleaned up Code of Conduct including adding Zenodo DOI
 - [#772](https://github.com/askap-vast/vast-pipeline/pull/772): fix, docs: Fixed changelog formatting and updated changelog release instructions

--- a/vast_pipeline/pipeline/config.py
+++ b/vast_pipeline/pipeline/config.py
@@ -405,7 +405,7 @@ class PipelineConfig:
             schema = yaml.Map({epoch: yaml.Seq(yaml.Str()) for epoch in epochs_image})
             for input_type in inputs.keys():
                 # Generate a new YAML object on-the-fly per input to avoid saving
-                # a validation schema per file in the PipelineConfig object 
+                # a validation schema per file in the PipelineConfig object
                 # (These can consume a lot of RAM for long lists of input files).
                 yaml.load(self._yaml["inputs"][input_type].as_yaml(), schema=schema)
         except yaml.YAMLValidationError:

--- a/vast_pipeline/pipeline/finalise.py
+++ b/vast_pipeline/pipeline/finalise.py
@@ -357,9 +357,9 @@ def final_operations(
     make_upload_associations(sources_df_upload)
 
     # write associations to parquet file
-    sources_df.rename(columns={'id': 'meas_id'})[
-        ['source_id', 'meas_id', 'd2d', 'dr']
-    ].to_parquet(os.path.join(p_run.path, 'associations.parquet'))
+    sources_df[['source_id', 'id', 'd2d', 'dr']]. \
+        rename(columns={'id': 'meas_id'}). \
+            to_parquet(os.path.join(p_run.path, 'associations.parquet'))
 
     if calculate_pairs:
         # get the Source object primary keys for the measurement pairs

--- a/vast_pipeline/pipeline/forced_extraction.py
+++ b/vast_pipeline/pipeline/forced_extraction.py
@@ -481,8 +481,8 @@ def write_forced_parquet(
     dfs = map(lambda x: (df[df['image'] == x], get_fname(x)), images)
 
     # Write parquets
-    for df, fname in dfs:
-        write_group_to_parquet(df, fname, add_mode)
+    for this_df, fname in dfs:
+        write_group_to_parquet(this_df, fname, add_mode)
     pass
 
 

--- a/vast_pipeline/pipeline/forced_extraction.py
+++ b/vast_pipeline/pipeline/forced_extraction.py
@@ -413,11 +413,10 @@ def parallel_extraction(
     ))
 
     # compute the rest of the columns
-    intermediate_df = (
-        db.from_sequence(intermediate_df)
-        .map(lambda x: finalise_forced_dfs(**x))
-        .compute()
-    )
+    intermediate_df = list(map(
+        lambda x: finalise_forced_dfs(**x),
+        intermediate_df
+        ))
     df_out = (
         pd.concat(intermediate_df, axis=0, sort=False)
         .rename(

--- a/vast_pipeline/utils/utils.py
+++ b/vast_pipeline/utils/utils.py
@@ -392,7 +392,7 @@ def timeStamped(fname, fmt="%Y-%m-%d-%H-%M-%S_{fname}"):
     return datetime.now().strftime(fmt).format(fname=fname)
 
 
-def calculate_n_partitions(df, n_cpu, partition_size_mb=100):
+def calculate_n_partitions(df, n_cpu, partition_size_mb=15):
     """
     This function will calculate how many partitions a dataframe should be
     split into.

--- a/vast_pipeline/utils/utils.py
+++ b/vast_pipeline/utils/utils.py
@@ -401,6 +401,14 @@ def calculate_n_partitions(df, n_cpu, partition_size_mb=15):
         df: The pandas dataframe to be partitionined.
         n_cpu: The number of available CPUs.
         partition_size: The optimal partition size in MB.
+            NOTE: The default partition size of 15MB is chosen because
+                many of the parallelised operations on partitioned
+                DataFrames can consume a much larger amount of memory
+                than the size of the partition. 15MB avoids consuming
+                too much memory for significant amounts of parallelism
+                (e.g. n_cpu > 10) without significant cost to processing
+                speed.
+
     Returns:
         The optimal number of partitions.
     """


### PR DESCRIPTION
These changes stop the quadrupling of dataframe in memory when using `iterrows` before upload to the database. There are also a few other minor changes to squeeze out a bit more memory at no cost to processing time.

It runs for me through forced extraction with ~2700 images - and through the measurment pairs with ~1000 images. The pairs dataframe just gets too big after 1000 images.

These changes should be good to hold over a 1.x release (no changes to the databse structure etc.) until further improvements in v2.x release which won't be backwards compatible.