### PR TITLE
Log how many sources are being forced-fit for each image

### DIFF
--- a/vast_pipeline/pipeline/finalise.py
+++ b/vast_pipeline/pipeline/finalise.py
@@ -332,14 +332,36 @@ def final_operations(
         .to_parquet(os.path.join(p_run.path, 'sources.parquet'))
     )
 
+    nr_sources = srcs_df["id"].count()
+    nr_new_sources = srcs_df['new'].sum()
+
+    # temp write to file:
+    sources_df.to_parquet('sources_df.parquet')
+    srcs_df.to_parquet('srcs_df.parquet')
+
     # update measurements with sources to get associations
-    sources_df = (
-        sources_df.drop('related', axis=1)
-        .merge(srcs_df.rename(columns={'id': 'source_id'}), on='source')
+    mem_usage = get_df_memory_usage(sources_df)
+    logger.debug(f"sources_df memory usage pre-drop: {mem_usage}MB")
+    mem_usage = get_df_memory_usage(srcs_df)
+    logger.debug(f"srcs_df memory usage pre-drop: {mem_usage}MB")
+    log_total_memory_usage()
+
+    sources_df = sources_df[['id', 'source', 'd2d', 'dr']]
+    srcs_df = srcs_df[['id']].rename(columns={'id': 'source_id'})
+    
+    mem_usage = get_df_memory_usage(sources_df)
+    logger.debug(f"sources_df memory usage post-drop: {mem_usage}MB")
+    mem_usage = get_df_memory_usage(srcs_df)
+    logger.debug(f"srcs_df memory usage post-drop: {mem_usage}MB")
+    log_total_memory_usage()
+    
+    associations_df = (
+        sources_df
+        .merge(srcs_df, on='source')
     )
 
-    mem_usage = get_df_memory_usage(sources_df)
-    logger.debug(f"sources_df memory after srcs_df merge: {mem_usage}MB")
+    mem_usage = get_df_memory_usage(associations_df)
+    logger.debug(f"associations_df memory after merge: {mem_usage}MB")
     log_total_memory_usage()
 
     if add_mode:
@@ -348,30 +370,30 @@ def final_operations(
             pd.read_parquet(previous_parquets['associations'])
             .rename(columns={'meas_id': 'id'})
         )
-        sources_df_upload = pd.concat(
-            [sources_df, old_assoications],
+        associations_df_upload = pd.concat(
+            [associations_df, old_assoications],
             ignore_index=True
         )
-        sources_df_upload = sources_df_upload.drop_duplicates(
+        associations_df_upload = associations_df_upload.drop_duplicates(
             ['source_id', 'id', 'd2d', 'dr'], keep=False
         )
         logger.debug(
-            f'Add mode: #{sources_df_upload.shape[0]} associations to upload.')
+            f'Add mode: #{associations_df_upload.shape[0]} associations to upload.')
     else:
-        sources_df_upload = sources_df
+        associations_df_upload = associations_df
 
     # upload associations into DB
-    make_upload_associations(sources_df_upload)
+    make_upload_associations(associations_df_upload)
 
     # write associations to parquet file
-    sources_df[['source_id', 'id', 'd2d', 'dr']]. \
+    associations_df[['source_id', 'id', 'd2d', 'dr']]. \
         rename(columns={'id': 'meas_id'}). \
             to_parquet(os.path.join(p_run.path, 'associations.parquet'))
 
     if calculate_pairs:
         # get the Source object primary keys for the measurement pairs
         measurement_pairs_df = measurement_pairs_df.join(
-            srcs_df.id.rename("source_id"), on="source"
+            srcs_df.source_id, on="source"
         )
 
         # optimize measurement pair DataFrame and save to parquet file
@@ -390,8 +412,7 @@ def final_operations(
         "Total final operations time: %.2f seconds",
         timer.reset_init())
 
-    nr_sources = srcs_df["id"].count()
-    nr_new_sources = srcs_df['new'].sum()
+    
 
     # calculate and return total number of extracted sources
     return (nr_sources, nr_new_sources)

--- a/vast_pipeline/pipeline/forced_extraction.py
+++ b/vast_pipeline/pipeline/forced_extraction.py
@@ -174,6 +174,8 @@ def extract_from_image(
         df['wavg_dec'].values,
         unit=(u.deg, u.deg)
     )
+    num_sources = len(df)
+    logger.debug(f"Will fit {num_sources} sources for {image}...")
     # load the image, background and noisemaps into memory
     # a dedicated function may seem unneccesary, but will be useful if we
     # split the load to a separate thread.
@@ -190,6 +192,13 @@ def extract_from_image(
         allow_nan=allow_nan,
         edge_buffer=edge_buffer
     )
+    
+    num_fits = np.sum(flux>0.0)
+    
+    logger.debug(f"{image}: Obtained {num_fits} measurements "
+                 f"({num_sources-num_fits} sources outside of image range)."
+                 )
+    
     df['flux_int'] = flux * 1.e3
     df['flux_int_err'] = flux_err * 1.e3
     df['chi_squared_fit'] = chisq


### PR DESCRIPTION
This branch now also
* uses numba functionality of ForcedPhot (requires installing this version: https://github.com/askap-vast/forced_phot/tree/initial-optimisations - I'll update the pyproject.toml etc before merging)
* Drops unnecessary columns prior to the associations upload step, reducing memory usage of the large dataframes by 10x