### PR TITLE
Github workflows: Update ubuntu versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.8.12", "3.9.10", "3.10"]
+        python_version: ["3.8.12", "3.9.12", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Updated ubuntu to 24.04 in github workflows [#810](https://github.com/askap-vast/vast-pipeline/pull/810)
 - Fixed broken links on pipeline websites [#802](https://github.com/askap-vast/vast-pipeline/pull/802)
 - Fixed outdated jupyterhub link on pipeline website [#795](https://github.com/askap-vast/vast-pipeline/pull/795)
 - Renamed variable in pipeline.finalise to better reflect what the dataframe represents (sources_df -> associations_df) [#787](https://github.com/askap-vast/vast-pipeline/pull/787)
@@ -35,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#810](https://github.com/askap-vast/vast-pipeline/pull/810): fix: Updated ubuntu to 24.04 in github workflows
 - [#806](https://github.com/askap-vast/vast-pipeline/pull/806): feat, docs: Added more detailed warnings about the use of Condon Errors throughout the docs and code
 - [#805](https://github.com/askap-vast/vast-pipeline/pull/805): docs: Added processing configuration parameters to the run configuration documentation 
 - [#802](https://github.com/askap-vast/vast-pipeline/pull/802): fix: Fix broken links on pipeline website

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
-- Updated ubuntu to 24.04 in github workflows [#810](https://github.com/askap-vast/vast-pipeline/pull/810)
+- Updated ubuntu to 24.04 in github workflows and bumped python versions accordingly [#810](https://github.com/askap-vast/vast-pipeline/pull/810)
 - Fixed broken links on pipeline websites [#802](https://github.com/askap-vast/vast-pipeline/pull/802)
 - Fixed outdated jupyterhub link on pipeline website [#795](https://github.com/askap-vast/vast-pipeline/pull/795)
 - Renamed variable in pipeline.finalise to better reflect what the dataframe represents (sources_df -> associations_df) [#787](https://github.com/askap-vast/vast-pipeline/pull/787)
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
-- [#810](https://github.com/askap-vast/vast-pipeline/pull/810): fix: Updated ubuntu to 24.04 in github workflows
+- [#810](https://github.com/askap-vast/vast-pipeline/pull/810): fix: Updated ubuntu to 24.04 in github workflows and bumped python versions accordingly 
 - [#806](https://github.com/askap-vast/vast-pipeline/pull/806): feat, docs: Added more detailed warnings about the use of Condon Errors throughout the docs and code
 - [#805](https://github.com/askap-vast/vast-pipeline/pull/805): docs: Added processing configuration parameters to the run configuration documentation 
 - [#802](https://github.com/askap-vast/vast-pipeline/pull/802): fix: Fix broken links on pipeline website


### PR DESCRIPTION
From Github:

> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
> 
> 
> March 4 14:00 UTC – 22:00 UTC
> March 11 13:00 UTC – 21:00 UTC
> March 18 13:00 UTC – 21:00 UTC
> March 25 13:00 UTC – 21:00 UTC
> What you need to do
> 
> Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the [runner images repository](https://app.github.media/e/er?s=88570519&lid=3455&elqTrackId=1befe7689f3c4a1a9cba67758d7c6fa0&elq=6302ee16333843d5a09bdd4e8e70ebbc&elqaid=4309&elqat=1&elqak=8AF512931A9D3060F4A93E1FC36635281ABF46353B67477A3FA19EB69375B1DCB079). Please contact GitHub [Support](https://app.github.media/e/er?s=88570519&lid=3338&elqTrackId=51ced43500f64a46924167a4a536829b&elq=6302ee16333843d5a09bdd4e8e70ebbc&elqaid=4309&elqat=1&elqak=8AF5D818E42E3357A6143F29D23F7AD3B3C146353B67477A3FA19EB69375B1DCB079) if you run into any problems or need help.