### PR TITLE
Clean up image header extraction to prevent memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Fixed potential memory leak in image header extraction [#828](https://github.com/askap-vast/vast-pipeline/pull/828)
 - Updated ubuntu to 24.04 in github workflows and bumped python versions accordingly [#810](https://github.com/askap-vast/vast-pipeline/pull/810)
 - Fixed broken links on pipeline websites [#802](https://github.com/askap-vast/vast-pipeline/pull/802)
 - Fixed outdated jupyterhub link on pipeline website [#795](https://github.com/askap-vast/vast-pipeline/pull/795)
@@ -36,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#828](https://github.com/askap-vast/vast-pipeline/pull/828): fix: Fix potential memory leak in image header extraction
 - [#810](https://github.com/askap-vast/vast-pipeline/pull/810): fix: Updated ubuntu to 24.04 in github workflows and bumped python versions accordingly 
 - [#806](https://github.com/askap-vast/vast-pipeline/pull/806): feat, docs: Added more detailed warnings about the use of Condon Errors throughout the docs and code
 - [#805](https://github.com/askap-vast/vast-pipeline/pull/805): docs: Added processing configuration parameters to the run configuration documentation 

--- a/vast_pipeline/image/main.py
+++ b/vast_pipeline/image/main.py
@@ -121,14 +121,14 @@ class FitsImage(Image):
 
         try:
             with open_fits(self.path) as hdulist:
-                hdu = hdulist[hdu_index]
+                header = hdulist[hdu_index].header.copy()
         except Exception:
             raise IOError((
                 'Could not read FITS file: '
                 f'{self.path}'
             ))
 
-        return hdu.header.copy()
+        return header
 
     def __set_img_attr_for_telescope(self, header):
         '''


### PR DESCRIPTION
Fix #827.

I'm not convinced this change _should_ do anything because in theory everything is contained inside a `with` statement, but based on testing it apparently does reduce memory usage.