### PR TITLE
Big speed-ups in association.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Changed
 
+- Speed up final step of basic/advanced association by not resetting index twice (factor of 5-100x faster!) [#861](https://github.com/askap-vast/vast-pipeline/pull/861)
+- Speed up wrap handling by not writing to main dataframe [#861](https://github.com/askap-vast/vast-pipeline/pull/861)
+- Speed up tmp_srcs_df groupby by not sorting (2x faster) [#861](https://github.com/askap-vast/vast-pipeline/pull/861)
+- Speed up various steps by not computing dataframe values multiple times [#861](https://github.com/askap-vast/vast-pipeline/pull/861)
+- Speed up cleanup step by using rename rather than copying and dropping [#861](https://github.com/askap-vast/vast-pipeline/pull/861)
 - Converted forced fits and sources removals for re-runs to use raw SQL queries [#840](https://github.com/askap-vast/vast-pipeline/pull/840)
 - Updated open_fits to correctly handle NaN-padded compressed images [#837](https://github.com/askap-vast/vast-pipeline/pull/837)
 - Upgrade measurements file generation to use dask in order to handle larger runs [#789](https://github.com/askap-vast/vast-pipeline/pull/797)
@@ -46,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#861](https://github.com/askap-vast/vast-pipeline/pull/861): fix, feat: Major optimisations in association step
 - [#840](https://github.com/askap-vast/vast-pipeline/pull/840): fix, feat: Optimise database clearing (sources, forced fits and runs)
 - [#858](https://github.com/askap-vast/vast-pipeline/pull/858): fix: Fixed adjacent skyregions not being grouped together
 - [#841](https://github.com/askap-vast/vast-pipeline/pull/841): fix: Fix incorrect changelog link, fix slow image initialisation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Speed up wrap handling by not writing to main dataframe [#861](https://github.com/askap-vast/vast-pipeline/pull/861)
 - Speed up tmp_srcs_df groupby by not sorting (2x faster) [#861](https://github.com/askap-vast/vast-pipeline/pull/861)
 - Speed up various steps by not computing dataframe values multiple times [#861](https://github.com/askap-vast/vast-pipeline/pull/861)
-- Speed up cleanup step by using rename rather than copying and dropping [#861](https://github.com/askap-vast/vast-pipeline/pull/861)
 - Converted forced fits and sources removals for re-runs to use raw SQL queries [#840](https://github.com/askap-vast/vast-pipeline/pull/840)
 - Updated open_fits to correctly handle NaN-padded compressed images [#837](https://github.com/askap-vast/vast-pipeline/pull/837)
 - Upgrade measurements file generation to use dask in order to handle larger runs [#789](https://github.com/askap-vast/vast-pipeline/pull/797)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- Fixed broken skyregion group tag in association logging [#861](https://github.com/askap-vast/vast-pipeline/pull/861)
 - Fixed extremely slow pipeline run deletion via batching [#840](https://github.com/askap-vast/vast-pipeline/pull/840)
 - Fixed adjacent skyregions not being grouped together by correcting the skyregion FoV, which was incorrectly using the radius when it should use the diameter [#858](https://github.com/askap-vast/vast-pipeline/pull/858)
 - Fixed slow image initialisation by disabling comp_nan_fill when fetching header [#841](https://github.com/askap-vast/vast-pipeline/pull/841)
@@ -50,7 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
-- [#861](https://github.com/askap-vast/vast-pipeline/pull/861): fix, feat: Major optimisations in association step
+- [#861](https://github.com/askap-vast/vast-pipeline/pull/861): fix, feat: Major optimisations and minor logging tweaks in association step
 - [#840](https://github.com/askap-vast/vast-pipeline/pull/840): fix, feat: Optimise database clearing (sources, forced fits and runs)
 - [#858](https://github.com/askap-vast/vast-pipeline/pull/858): fix: Fixed adjacent skyregions not being grouped together
 - [#841](https://github.com/askap-vast/vast-pipeline/pull/841): fix: Fix incorrect changelog link, fix slow image initialisation

--- a/vast_pipeline/pipeline/association.py
+++ b/vast_pipeline/pipeline/association.py
@@ -1304,7 +1304,7 @@ def association(
                     'weight_ns'
                 ]
             ]
-            .groupby('source')
+            .groupby('source', sort=False)
         )
 
         stats = StopWatch()

--- a/vast_pipeline/pipeline/association.py
+++ b/vast_pipeline/pipeline/association.py
@@ -1309,11 +1309,14 @@ def association(
 
         stats = StopWatch()
 
-        wm_ra = tmp_srcs_df['interim_ew'].sum() / tmp_srcs_df['weight_ew'].sum()
-        wm_uncertainty_ew = 1. / np.sqrt(tmp_srcs_df['weight_ew'].sum())
+        weight_ew = tmp_srcs_df['weight_ew'].sum()
+        weight_ns = tmp_srcs_df['weight_ns'].sum()
 
-        wm_dec = tmp_srcs_df['interim_ns'].sum() / tmp_srcs_df['weight_ns'].sum()
-        wm_uncertainty_ns = 1. / np.sqrt(tmp_srcs_df['weight_ns'].sum())
+        wm_ra = tmp_srcs_df['interim_ew'].sum() / weight_ew
+        wm_uncertainty_ew = 1. / np.sqrt(weight_ew)
+
+        wm_dec = tmp_srcs_df['interim_ns'].sum() / weight_ns
+        wm_uncertainty_ns = 1. / np.sqrt(weight_ns)
 
         weighted_df = (
             pd.concat(

--- a/vast_pipeline/pipeline/association.py
+++ b/vast_pipeline/pipeline/association.py
@@ -864,7 +864,7 @@ def basic_association(
     sources_df = pd.concat(
         [sources_df, skyc2_srcs],
         ignore_index=True
-    ).reset_index(drop=True)
+    )
 
     # and update skyc1 with the sources that were created from the one
     # to many relations and any new sources.
@@ -876,7 +876,7 @@ def basic_association(
             ]
         ],
         ignore_index=True
-    ).reset_index(drop=True)
+    )
 
     return sources_df, skyc1_srcs
 

--- a/vast_pipeline/pipeline/association.py
+++ b/vast_pipeline/pipeline/association.py
@@ -1357,12 +1357,18 @@ def association(
         )
         del tmp_srcs_df, weighted_df
 
-        skyc1_srcs = skyc1_srcs.rename(columns={
-            'ra_skyc2': 'ra',
-            'dec_skyc2': 'dec',
-            'uncertainty_ew_skyc2': 'uncertainty_ew',
-            'uncertainty_ns_skyc2': 'uncertainty_ns',
-        })
+        skyc1_srcs['ra'] = skyc1_srcs['ra_skyc2']
+        skyc1_srcs['dec'] = skyc1_srcs['dec_skyc2']
+        skyc1_srcs['uncertainty_ew'] = skyc1_srcs['uncertainty_ew_skyc2']
+        skyc1_srcs['uncertainty_ns'] = skyc1_srcs['uncertainty_ns_skyc2']
+        skyc1_srcs = skyc1_srcs.drop(
+            [
+                'ra_skyc2',
+                'dec_skyc2',
+                'uncertainty_ew_skyc2',
+                'uncertainty_ns_skyc2'
+            ], axis=1
+        )
 
         # generate new sky coord ready for next iteration
         skyc1 = SkyCoord(

--- a/vast_pipeline/pipeline/association.py
+++ b/vast_pipeline/pipeline/association.py
@@ -1356,18 +1356,13 @@ def association(
             suffixes=('', '_skyc2')
         )
         del tmp_srcs_df, weighted_df
-        skyc1_srcs['ra'] = skyc1_srcs['ra_skyc2']
-        skyc1_srcs['dec'] = skyc1_srcs['dec_skyc2']
-        skyc1_srcs['uncertainty_ew'] = skyc1_srcs['uncertainty_ew_skyc2']
-        skyc1_srcs['uncertainty_ns'] = skyc1_srcs['uncertainty_ns_skyc2']
-        skyc1_srcs = skyc1_srcs.drop(
-            [
-                'ra_skyc2',
-                'dec_skyc2',
-                'uncertainty_ew_skyc2',
-                'uncertainty_ns_skyc2'
-            ], axis=1
-        )
+
+        skyc1_srcs = skyc1_srcs.rename(columns={
+            'ra_skyc2': 'ra',
+            'dec_skyc2': 'dec',
+            'uncertainty_ew_skyc2': 'uncertainty_ew',
+            'uncertainty_ns_skyc2': 'uncertainty_ns',
+        })
 
         # generate new sky coord ready for next iteration
         skyc1 = SkyCoord(

--- a/vast_pipeline/pipeline/association.py
+++ b/vast_pipeline/pipeline/association.py
@@ -1237,9 +1237,17 @@ def association(
         )
         logger.debug('len(skyc1): %i%s', len(skyc1_srcs), skyreg_tag)
         # load skyc2 source measurements and create SkyCoord
+        images_df_rows = images_df.loc[images_df['epoch'] == epoch]
         images = (
-            images_df.loc[images_df['epoch'] == epoch, 'image_dj'].to_list()
+            images_df_rows['image_dj'].to_list()
         )
+        image_names = (
+            images_df_rows['image_name'].to_list()
+        )
+        
+        image_name_str = ",".join(image_names)
+        logger.info('Loaded %s%s', image_name_str, skyreg_tag)
+
         max_beam_maj = (
             images_df.loc[images_df['epoch'] == epoch, 'image_dj']
             .apply(lambda x: x.beam_bmaj)

--- a/vast_pipeline/pipeline/association.py
+++ b/vast_pipeline/pipeline/association.py
@@ -1283,20 +1283,17 @@ def association(
         )
 
         # account for RA wrapping
-        ra_wrap_mask = sources_df.ra <= 0.1
-        sources_df['ra_wrap'] = sources_df.ra.values
-        sources_df.loc[
-            ra_wrap_mask, 'ra_wrap'
-        ] = sources_df[ra_wrap_mask].ra.values + 360.
+        ra = sources_df.ra.values
+        dec = sources_df.dec.values
+        ra_wrap_mask = ra <= 0.1 # Why is this 0.1 and not 0.0? Is this the cause of issue 711?
+        ra[ra_wrap_mask] = ra[ra_wrap_mask]+360.
 
         sources_df['interim_ew'] = (
-            sources_df['ra_wrap'].values * sources_df['weight_ew'].values
+            ra * sources_df['weight_ew'].values
         )
         sources_df['interim_ns'] = (
             sources_df['dec'].values * sources_df['weight_ns'].values
         )
-
-        sources_df = sources_df.drop(['ra_wrap'], axis=1)
 
         tmp_srcs_df = (
             sources_df.loc[

--- a/vast_pipeline/pipeline/association.py
+++ b/vast_pipeline/pipeline/association.py
@@ -1031,14 +1031,14 @@ def advanced_association(
     sources_df = pd.concat(
         [sources_df, skyc2_srcs_toappend],
         ignore_index=True
-    ).reset_index(drop=True)
+    )
 
     # update skyc1 and df for next association iteration
     # calculate average angles for skyc1
     skyc1_srcs = pd.concat(
         [skyc1_srcs, new_sources],
         ignore_index=True
-    ).reset_index(drop=True)
+    )
 
     # also need to append any related sources that created a new
     # source, we can use the skyc2_srcs_toappend to get these

--- a/vast_pipeline/pipeline/association.py
+++ b/vast_pipeline/pipeline/association.py
@@ -1225,8 +1225,17 @@ def association(
         unit=(u.deg, u.deg)
     )
 
-    for it, epoch in enumerate(unique_epochs[start_epoch:]):
-        logger.info('Association iteration: #%i%s', it + 1, skyreg_tag)
+    iter_timer = StopWatch()
+    epochs = unique_epochs[start_epoch:]
+    num_iterations = len(epochs)
+    for it, epoch in enumerate(epochs):
+        logger.info(
+            'Starting association iteration: %i/%i%s',
+            it + 1,
+            num_iterations,
+            skyreg_tag
+        )
+        logger.debug('len(skyc1): %i%s', len(skyc1_srcs), skyreg_tag)
         # load skyc2 source measurements and create SkyCoord
         images = (
             images_df.loc[images_df['epoch'] == epoch, 'image_dj'].to_list()
@@ -1241,6 +1250,7 @@ def association(
             config["measurements"]["flux_fractional_error"],
             duplicate_limit
         )
+        logger.debug('len(skyc2_srcs): %i%s', len(skyc2_srcs), skyreg_tag)
 
         skyc2_srcs['epoch'] = epoch
         skyc2 = SkyCoord(
@@ -1249,6 +1259,8 @@ def association(
             unit=(u.deg, u.deg)
         )
 
+        
+        iter_timer.reset()
         if method == 'basic':
             sources_df, skyc1_srcs = basic_association(
                 sources_df,
@@ -1280,6 +1292,11 @@ def association(
             )
         else:
             raise Exception('association method not implemented!')
+        logger.debug(
+            'Time to carry out association: %.2f%s',
+            iter_timer.reset(),
+            skyreg_tag
+        )
 
         logger.info(
             'Calculating weighted average RA and Dec for sources%s...',
@@ -1287,6 +1304,7 @@ def association(
         )
 
         # account for RA wrapping
+        iter_timer.reset()
         ra = sources_df.ra.values
         dec = sources_df.dec.values
         ra_wrap_mask = ra <= 0.1 # Why is this 0.1 and not 0.0? Is this the cause of issue 711?
@@ -1310,8 +1328,11 @@ def association(
             ]
             .groupby('source', sort=False)
         )
-
-        stats = StopWatch()
+        logger.debug(
+            'Time to handle RA wrapping: %.2f%s',
+            iter_timer.reset(),
+            skyreg_tag
+        )
 
         weight_ew = tmp_srcs_df['weight_ew'].sum()
         weight_ns = tmp_srcs_df['weight_ns'].sum()
@@ -1345,7 +1366,11 @@ def association(
             ra_wrap_mask, 'ra'
         ] = weighted_ra[ra_wrap_mask] - 360.
 
-        logger.debug('Groupby concat time %f', stats.reset())
+        logger.debug(
+            'Time to recalculate wavg coordinates: %.2f%s',
+            iter_timer.reset(),
+            skyreg_tag
+        )
 
         logger.info(
             'Finalising base sources catalogue ready for next iteration%s...',
@@ -1393,9 +1418,18 @@ def association(
         skyc1_srcs = skyc1_srcs.merge(
             relations_unique, how='left', left_on='source', right_index=True
         )
+        
+        logger.debug(
+            'Time to finalise sources: %.2f%s',
+            iter_timer.reset(),
+            skyreg_tag
+        )
 
         logger.info(
-            'Association iteration #%i complete%s.', it + 1, skyreg_tag
+            'Completed association iteration: %i/%i%s',
+            it + 1,
+            num_iterations,
+            skyreg_tag
         )
 
     # End of iteration over images, ra and dec columns are actually the

--- a/vast_pipeline/pipeline/association.py
+++ b/vast_pipeline/pipeline/association.py
@@ -1122,10 +1122,14 @@ def association(
 
     if 'skyreg_group' in images_df.columns:
         skyreg_group = images_df['skyreg_group'].iloc[0]
-        skyreg_tag = " (sky region group %s)" % skyreg_group
+    elif images_df.index.name == 'skyreg_group':
+        skyreg_group = images_df.index[0]
     else:
         skyreg_group = -1
         skyreg_tag = ""
+
+    if skyreg_group > 0:
+        skyreg_tag = " (sky region group %s)" % skyreg_group
 
     method = config["source_association"]["method"]
 

--- a/vast_pipeline/pipeline/association.py
+++ b/vast_pipeline/pipeline/association.py
@@ -1335,10 +1335,11 @@ def association(
         )
 
         # correct the RA wrapping
-        ra_wrap_mask = weighted_df.ra >= 360.
+        weighted_ra = weighted_df.ra.values
+        ra_wrap_mask = weighted_ra >= 360.
         weighted_df.loc[
             ra_wrap_mask, 'ra'
-        ] = weighted_df[ra_wrap_mask].ra.values - 360.
+        ] = weighted_ra[ra_wrap_mask] - 360.
 
         logger.debug('Groupby concat time %f', stats.reset())
 


### PR DESCRIPTION
* Speed up final step of basic/advanced association by not resetting index twice
* Speed up wrap handling by not writing to main dataframe
* Speed up tmp_srcs_df groupby by not sorting
* Speed up various steps by not computing dataframe values multiple times

Fix #860 
Fix #857 
Fix #835