### PR TITLE
Capture worker logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Added
 
+- V2: Forward logging from Dask workers to the client [#877](https://github.com/askap-vast/vast-pipeline/pull/877)
 - V2: Added functionality to throttle parallel database uploads [#852](https://github.com/askap-vast/vast-pipeline/pull/852)
 - V2: Added Dask cluster memory usage logging [#852](https://github.com/askap-vast/vast-pipeline/pull/852)
 - V2: Enable specification of Dask worker memory limits [#843](https://github.com/askap-vast/vast-pipeline/pull/843)
@@ -81,6 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#877](https://github.com/askap-vast/vast-pipeline/pull/877): feat: V2: Capture worker logs by client
 - [#854](https://github.com/askap-vast/vast-pipeline/pull/854): fix: V2: Fixed memory leaks caused by nested delays
 - [#852](https://github.com/askap-vast/vast-pipeline/pull/852): feat: V2: Switch worker throttling to use Dask Semaphore and add Dask cluster memory usage logging
 - [#846](https://github.com/askap-vast/vast-pipeline/pull/846): fix: V2: Compute associations prior to upload and persist srcs_df in final pairs calculation

--- a/vast_pipeline/daskmanager/manager.py
+++ b/vast_pipeline/daskmanager/manager.py
@@ -4,7 +4,7 @@ import logging
 import random
 import time
 
-from dask.distributed import Client, LocalCluster, Semaphore
+from dask.distributed import Client, LocalCluster, Semaphore, WorkerPlugin
 from django.conf import settings as s
 from . import config # noqa: F401
 
@@ -29,6 +29,8 @@ def _start_cluster():
             dashboard_address=f"{s.DASK_DASHBOARD_HOST}:{s.DASK_DASHBOARD_PORT}",
         )
     client = Client(cluster)
+    # Register our new plugin to log worker names
+    client.register_plugin(LogWorkerNamePlugin())
     logger.info('Connected to local Dask Cluster')
     return client
 
@@ -58,6 +60,54 @@ def get_db_semaphore(num_workers: int=None):
     if num_workers is None:
         num_workers = int(s.DASK_NUM_DB_WORKERS)
     return Semaphore(name='db_throttle', max_leases=num_workers)
+
+class WorkerLogFilter(logging.Filter):
+    """
+    Logging filter to inject the worker id into the LogRecord.
+    """
+    def __init__(self, worker = '0'):
+        self.worker = worker
+
+    def filter(self, record):
+        # Inject worker ID to the LogeRecord
+        record.msg = f'WORKER:{self.worker} {record.msg}'
+        return True
+
+class QuietStreamHandler(logging.StreamHandler):
+    """
+    Custom logging handler that prevents writing to
+    stderr by the workers.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def emit(self, record):
+        # Override emit to do nothing
+        pass
+
+class LogWorkerNamePlugin(WorkerPlugin):
+    """
+    A Dask WorkerPlugin to log the worker name in worker logging messages.
+    Also sets up a custom logging handler to prevent
+    workers from writing to stderr.
+    """
+    def setup(self, worker):
+        worker_name = worker.name
+        logger = logging.getLogger('')
+        logger.setLevel(logging.DEBUG)
+        # Find the existing StreamHandler and remove it
+        for handler in logger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                logger.removeHandler(handler)
+        # Add the QuietStreamHandler to suppress stderr output
+        quiet_handler = QuietStreamHandler()
+        logger.addHandler(quiet_handler)
+
+        # Add a filter to inject worker name into log records
+        worker_filter = WorkerLogFilter(worker=worker_name)
+
+        for handler in logger.handlers:
+            handler.addFilter(worker_filter)
 
 class Singleton(type):
     _instances = {}

--- a/vast_pipeline/management/commands/runpipeline.py
+++ b/vast_pipeline/management/commands/runpipeline.py
@@ -80,9 +80,9 @@ def run_pipe(
     '''
     path = run_dj_obj.path if run_dj_obj else path_name
     # set up logging for running pipeline from UI
+    root_logger = logging.getLogger('')
     if not cli:
         # set up the logger for the UI job
-        root_logger = logging.getLogger('')
         if debug:
             root_logger.setLevel(logging.DEBUG)
         f_handler = logging.FileHandler(
@@ -98,6 +98,9 @@ def run_pipe(
         validate_config=False,  # delay validation
         skip_connect=skip_connect,
     )
+
+    # Forward all logging from workers to the main logger
+    pipeline.dm.client.forward_logging('', root_logger.level)
 
     # Create the pipeline run in DB
     p_run, flag_exist = get_create_p_run(


### PR DESCRIPTION
Take logs from the worker processes and forward them to the client.

Worker logs have a `WORKER:{id}` appended before their log message.