### PR TITLE
Move forced measurement deletion to delete_run and optimise it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### Fixed
 
+- V2: Fix and optimise forced measurement deletion [#887](https://github.com/askap-vast/vast-pipeline/pull/887)
 - V2: Fix association upload to work with dask > 2025.5.0 [#879](https://github.com/askap-vast/vast-pipeline/pull/879)
 - V2: Fixed memory leaks caused by nested delays [#854](https://github.com/askap-vast/vast-pipeline/pull/854)
 - V2: Fixed duplicate source ID error by switching from sources_df.repartition() to sources_df.shuffle() in pipeline.finalise.final_operations [#845](https://github.com/askap-vast/vast-pipeline/pull/845)
@@ -85,6 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 #### List of PRs
 
+- [#887](https://github.com/askap-vast/vast-pipeline/pull/887): fix: V2: Move forced measurement deletion to delete_run and optimise it
 - [#880](https://github.com/askap-vast/vast-pipeline/pull/880): fix: V2: Ensure external dependencies pass when etxternal websites are down
 - [#879](https://github.com/askap-vast/vast-pipeline/pull/879): fix: V2: Update dependencies to work with latest python 3.11&3.12 and pin them
 - [#877](https://github.com/askap-vast/vast-pipeline/pull/877): feat: V2: Capture worker logs by client

--- a/vast_pipeline/management/commands/clearpiperun.py
+++ b/vast_pipeline/management/commands/clearpiperun.py
@@ -8,11 +8,10 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
 from vast_pipeline.models import Run
-from vast_pipeline.pipeline.forced_extraction import remove_forced_meas
 from vast_pipeline.utils.utils import StopWatch, delete_file_or_dir
 from ..helpers import get_p_run_name
 
-from ...utils.delete_run import delete_pipeline_run_raw_sql
+from ...utils.delete_run import delete_pipeline_run_raw_sql, remove_forced_meas
 
 logger = logging.getLogger(__name__)
 
@@ -135,8 +134,8 @@ class Command(BaseCommand):
             t = timer.reset()
             logger.info("Time to delete run from database: %.2f sec", t)
 
-            # remove forced measurements in db if presents
-            forced_parquets = remove_forced_meas(p_run.path)
+            # remove forced measurements in db if present
+            remove_forced_meas(p_run.path)
             t = timer.reset()
             logger.info("Time to delete forced measurements: %.2f sec", t)
 

--- a/vast_pipeline/management/commands/runpipeline.py
+++ b/vast_pipeline/management/commands/runpipeline.py
@@ -18,7 +18,6 @@ from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
 
 from vast_pipeline._version import __version__ as pipeline_version
-from vast_pipeline.pipeline.forced_extraction import remove_forced_meas
 from vast_pipeline.pipeline.main import Pipeline
 from vast_pipeline.pipeline.utils import (
     get_create_p_run, create_measurements_parquet_file,
@@ -27,6 +26,7 @@ from vast_pipeline.pipeline.utils import (
 from vast_pipeline.utils.utils import (
     StopWatch, timeStamped, delete_file_or_dir
 )
+from vast_pipeline.utils.delete_run import remove_forced_meas
 from vast_pipeline.models import Run
 from ..helpers import get_p_run_name
 

--- a/vast_pipeline/pipeline/forced_extraction.py
+++ b/vast_pipeline/pipeline/forced_extraction.py
@@ -13,13 +13,12 @@ from glob import glob
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from django.conf import settings
-from django.db import transaction
 from pyarrow.parquet import read_schema
 from typing import List, Tuple, Dict, Optional
 from dask.delayed import delayed
 from dask.distributed import wait
 
-from vast_pipeline.models import Image, Measurement, Run
+from vast_pipeline.models import Image, Run
 from vast_pipeline.pipeline.loading import copy_upload_measurements
 from vast_pipeline.daskmanager.manager import get_io_semaphore
 

--- a/vast_pipeline/pipeline/forced_extraction.py
+++ b/vast_pipeline/pipeline/forced_extraction.py
@@ -41,41 +41,6 @@ __TESTING__ = settings.TESTING
 logger = logging.getLogger(__name__)
 
 
-def remove_forced_meas(run_path: str, batch_size=10000) -> None:
-    """
-    Remove forced measurements from the database if forced parquet files
-    are found.
-
-    Args:
-        run_path:
-            The run path of the pipeline run.
-        batch_size:
-            Number of forced measurements to delete per iteration
-
-    Returns:
-        None
-    """
-    path_glob = glob(os.path.join(run_path, "forced_measurements_*.parquet"))
-    if path_glob:
-        ids = dd.read_parquet(path_glob, columns="id").values.compute().tolist()
-        forced_meas = Measurement.objects.filter(id__in=ids)
-        if forced_meas.exists():
-            with transaction.atomic():
-                ids_to_delete = list(forced_meas.values_list('id', flat=True))
-                n_ids = len(ids_to_delete)
-                
-                logger.info("Iterating over %d forced measurements", n_ids)
-                n_batches = round(n_ids/batch_size)
-                logger.info("Using %d batches of %d measurements", n_batches, batch_size)
-
-                total_deleted = 0
-                for i in range(0, n_ids, batch_size):
-                    batch_ids = ids_to_delete[i : i + batch_size]
-                    n_deleted, _ = Measurement.objects.filter(id__in=batch_ids).delete()
-                    total_deleted += n_deleted
-
-                logger.info('Total objects deleted: %i', total_deleted)
-
 def get_data_from_parquet(
     file_and_image_id: Tuple[str, int], p_run_path: str, add_mode: bool = False
 ) -> Dict:

--- a/vast_pipeline/utils/delete_run.py
+++ b/vast_pipeline/utils/delete_run.py
@@ -1,6 +1,11 @@
 import logging
+import math
+import os
+
+from glob import glob
 
 from tqdm import tqdm
+import dask.dataframe as dd
 from django.db import connection
 from vast_pipeline.utils.utils import StopWatch
 
@@ -192,3 +197,60 @@ def clear_run_sources(p_run_id, batch_size=10_000, timer=None):
         
         t = timer.reset()
         logger.info("Time to delete source objects: %.2f seconds", t)
+
+def remove_forced_meas(run_path: str, batch_size: int = 10000) -> None:
+    """
+    Remove forced measurements from the database if forced parquet files
+    are found.
+
+    Args:
+        run_path:
+            The run path of the pipeline run.
+        batch_size:
+            Number of forced measurements to delete per iteration.
+
+    Returns:
+        None
+    """
+    path_glob = glob(os.path.join(run_path, "forced_measurements_*.parquet"))
+
+    # Collect all forced measurement IDs from every parquet file simultaneously
+    if not path_glob:
+        logger.info("No forced measurement parquet files found in %s", run_path)
+        return
+    all_ids = dd.read_parquet(path_glob, columns=["id"])["id"].compute().tolist()
+
+    if not all_ids:
+        logger.info("No forced measurements found in parquet files in %s", run_path)
+        return
+
+    n_ids = len(all_ids)
+    n_batches = math.ceil(n_ids / batch_size)
+    logger.info(
+        "Deleting %d forced measurements in %d batches of %d",
+        n_ids, n_batches, batch_size,
+    )
+
+    timer = StopWatch()
+    total_deleted = 0
+    batch_starts = list(range(0, n_ids, batch_size))
+    with connection.cursor() as cursor:
+        for i in tqdm(batch_starts):
+            batch = all_ids[i : i + batch_size]
+            id_str = ",".join(f"'{mid}'" for mid in batch)
+
+            # Remove associations first (FK constraint)
+            cursor.execute(
+                f"DELETE FROM vast_pipeline_association WHERE meas_id IN ({id_str});"
+            )
+
+            # Delete the measurements themselves
+            cursor.execute(
+                f"DELETE FROM vast_pipeline_measurement WHERE id IN ({id_str});"
+            )
+            total_deleted += cursor.rowcount
+
+    t = timer.reset()
+    logger.info(
+        "Deleted %d forced measurements in %.2f seconds", total_deleted, t
+    )

--- a/vast_pipeline/utils/delete_run.py
+++ b/vast_pipeline/utils/delete_run.py
@@ -113,7 +113,7 @@ def delete_pipeline_run_raw_sql(p_run, source_batch_size=10000, delete_images=Fa
             image_count = cursor.fetchone()[0]
             # Delete skyregions that no longer have an image associated with them
             if image_count > 0:
-                logger.debug("Not deleting skyregion_id %d; %d image(s) still reference it.", sky_id, image_count)
+                logger.debug("Not deleting skyregion_id %s; %d image(s) still reference it.", sky_id, image_count)
                 continue
             else:
                 sql_cmd = f"DELETE FROM vast_pipeline_skyregion WHERE id = '{sky_id}';"


### PR DESCRIPTION
Move the remove_forced_meas from forced_extraction.py to delete_run.py and optimise it to use direct SQL commands rather than django.
This fixes an issue with large run deletion crashing when trying to remove forced measurements from the database and speeds up forced measurement deletion significantly.