### PR TITLE
Fix ci-docs-dev and ci-docs-release

### DIFF
--- a/.github/workflows/ci-docs-dev.yml
+++ b/.github/workflows/ci-docs-dev.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - uses: Gr1N/setup-poetry@v9
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential libpq-dev libgraphviz-dev

--- a/.github/workflows/ci-docs-dev.yml
+++ b/.github/workflows/ci-docs-dev.yml
@@ -16,8 +16,11 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
-      - uses: Gr1N/setup-poetry@v9
+          python-version: 3.10
+      - uses: snok/setup-poetry@v1
+        with:
+          version: 2.4.1
+          virtualenvs-in-project: true
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential libpq-dev libgraphviz-dev
       - name: Cache Python dependencies

--- a/.github/workflows/ci-docs-dev.yml
+++ b/.github/workflows/ci-docs-dev.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.10
-      - uses: snok/setup-poetry@v1
+      - uses: snok/install-poetry@v1
         with:
           version: 2.4.1
           virtualenvs-in-project: true

--- a/.github/workflows/ci-docs-dev.yml
+++ b/.github/workflows/ci-docs-dev.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: snok/install-poetry@v1
         with:
           version: 2.4.1

--- a/.github/workflows/ci-docs-release.yml
+++ b/.github/workflows/ci-docs-release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.10
-      - uses: snok/setup-poetry@v1
+      - uses: snok/install-poetry@v1
         with:
           version: 2.4.1
           virtualenvs-in-project: true

--- a/.github/workflows/ci-docs-release.yml
+++ b/.github/workflows/ci-docs-release.yml
@@ -13,8 +13,11 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
-      - uses: Gr1N/setup-poetry@v9
+          python-version: 3.10
+      - uses: snok/setup-poetry@v1
+        with:
+          version: 2.4.1
+          virtualenvs-in-project: true
       - name: Set release notes tag
         run: |
           export RELEASE_TAG_VERSION=${{ github.event.release.tag_name }}

--- a/.github/workflows/ci-docs-release.yml
+++ b/.github/workflows/ci-docs-release.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - uses: Gr1N/setup-poetry@v9
       - name: Set release notes tag
         run: |

--- a/.github/workflows/ci-docs-release.yml
+++ b/.github/workflows/ci-docs-release.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: snok/install-poetry@v1
         with:
           version: 2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 #### List of PRs
-- [#890](https://github.com/askap-vast/vast-pipeline/pull/890): fix: Update ci-docs github actions to be compatible with new poetry
+- [#890](https://github.com/askap-vast/vast-pipeline/pull/891): fix: Update ci-docs github actions to be compatible with new poetry
 - [#889](https://github.com/askap-vast/vast-pipeline/pull/889): fix: Ensure external dependencies pass when etxternal websites are down
 - [#888](https://github.com/askap-vast/vast-pipeline/pull/888): fix: Move forced measurement deletion to delete_run and optimise it
 - [#885](https://github.com/askap-vast/vast-pipeline/pull/885): fix: Fix bug introduced by #884 regarding error handling of external query table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 #### List of PRs
+- [#890](https://github.com/askap-vast/vast-pipeline/pull/890): fix: Update ci-docs github actions to be compatible with new poetry
 - [#889](https://github.com/askap-vast/vast-pipeline/pull/889): fix: Ensure external dependencies pass when etxternal websites are down
 - [#888](https://github.com/askap-vast/vast-pipeline/pull/888): fix: Move forced measurement deletion to delete_run and optimise it
 - [#885](https://github.com/askap-vast/vast-pipeline/pull/885): fix: Fix bug introduced by #884 regarding error handling of external query table


### PR DESCRIPTION
These were failing since the latest poetry version doesn;t work with the pinned python version 3.9.

Fix is to update the pinned version of python to 3.10 and pin poetry to 2.4.1.

This is an update to #890 to fix a typo in the install-poetry action