### PR TITLE
Docs Hotfix: replace polyfill link with cloudflare secure alternative

### DIFF
--- a/docs/developing/docsdev.md
+++ b/docs/developing/docsdev.md
@@ -63,7 +63,7 @@ Custom javascript and css files are also stored in this directory and are enable
       - theme/css/extra.css
     extra_javascript:
       - theme/js/extra.js
-      - https://polyfill.io/v3/polyfill.min.js?features=es6
+      - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
       - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
     ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,7 @@ extra_css:
   - theme/css/extra.css
 extra_javascript:
   - theme/js/extra.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Per https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet/